### PR TITLE
Elements with VR UN (explicit VR) now keep this VR in ParseFlow

### DIFF
--- a/src/main/scala/se/nimsa/dicom/streams/ModifyFlow.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/ModifyFlow.scala
@@ -67,7 +67,7 @@ object ModifyFlow {
     *
     * Note that modified DICOM data may not be valid. This function does not ensure values are padded to even length and
     * changing an element may lead to invalid group length elements such as MediaStorageSOPInstanceUID. There are
-    * utility functions in `se.nimsa.ddcm4che.data` for padding values and flows for adjusting group lengths.
+    * utility functions in `se.nimsa.dicom.data` for padding values and flows for adjusting group lengths.
     *
     * @param modifications Any number of `TagModification`s each specifying a tag path, a modification function, and
     *                      a Boolean indicating whether absent values will be inserted or skipped.
@@ -118,16 +118,10 @@ object ModifyFlow {
       def findModifyPart(header: HeaderPart): List[DicomPart] = sortedModifications
         .find(m => m.matches(tagPath))
         .map { tagModification =>
-          if (header.length > 0) {
-            currentHeader = Some(header)
-            currentModification = Some(tagModification)
-            value = ByteString.empty
-            Nil
-          } else {
-            val newValue = tagModification.modification(ByteString.empty)
-            val newHeader = header.withUpdatedLength(newValue.length)
-            newHeader :: valueOrNot(newValue)
-          }
+          currentHeader = Some(header)
+          currentModification = Some(tagModification)
+          value = ByteString.empty
+          Nil
         }
         .getOrElse(header :: Nil)
 


### PR DESCRIPTION
This bug was messing with DICOM files with explicit VR that included elements with VR encoded as UN but which have known VRs according to the dictionary. The file in question included the element PatientIdentityRemoved which has VR CS according to the dictionary but was encoded with VR UN in the file. This bug fix makes sure the VR stays UN is these cases. ParseFlow should not change the data!