### PR TITLE
Bugfix/#25 whitelist preserve structure

### DIFF
--- a/src/main/scala/se/nimsa/dicom/data/TagPath.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagPath.scala
@@ -16,45 +16,32 @@
 
 package se.nimsa.dicom.data
 
+import se.nimsa.dicom.data.TagPath._
+
 import scala.annotation.tailrec
 
-sealed trait TagPath {
+sealed trait TagPath extends TagPathLike {
 
-  import TagPath._
+  override type P = TagPath
+  override type T = TagPathTrunk
+  override type E = EmptyTagPath.type
+
+  override protected val empty: E = EmptyTagPath
 
   def tag: Int
-  def previous: TagPathTrunk
-
-  /**
-    * `true` if this tag path points to the root dataset, at depth 0
-    */
-  lazy val isRoot: Boolean = previous.isEmpty
-  lazy val isEmpty: Boolean = this eq EmptyTagPath
-
-  def toList: List[TagPath] = {
-    @tailrec
-    def toList(path: TagPath, tail: List[TagPath]): List[TagPath] =
-      if (path.isRoot) path :: tail else toList(path.previous, path :: tail)
-
-    if (isEmpty) Nil else toList(path = this, tail = Nil)
-  }
 
   /**
     * Test if this tag path is less than the input path, comparing their parts pairwise from root to leaf according to
     * the following rules:
     * (1) a is less than b if the a's tag number is less b's tag number
     * (2) a is less than b if tag numbers are equal and a's item index is less than b's item index
-    * in all other cases a is not less than b. Note that this means that the ordering of sequence items and sequence
-    * wildcards with the same tag number is not defined, e.g. the path `(300A,00B0)[1]` is equal in terms of ordering to
-    * `(300A,00B0)[*]` in the sense that `(300A,00B0)[1] &lt; (300A,00B0)[*] = false` and
-    * `(300A,00B0)[*] &lt; (300A,00B0)[1] = false`.
     *
     * @param that the tag path to compare with
     * @return `true` if this tag path is less than the input path
     */
   def <(that: TagPath): Boolean = {
-    val thisList = this.toList
-    val thatList = that.toList
+    val thisList: List[TagPath] = this.toList
+    val thatList: List[TagPath] = that.toList
 
     thisList.zip(thatList).foreach {
       case (EmptyTagPath, thatPath) =>
@@ -63,7 +50,7 @@ sealed trait TagPath {
         return false
       case (thisPath, thatPath) if thisPath.tag != thatPath.tag =>
         return intToUnsignedLong(thisPath.tag) < intToUnsignedLong(thatPath.tag)
-      case (thisPath: TagPathSequenceItem, thatPath: TagPathSequenceItem) if thisPath.item != thatPath.item =>
+      case (thisPath: TagPath with ItemIndex, thatPath: TagPath with ItemIndex) if thisPath.item != thatPath.item =>
         return thisPath.item < thatPath.item
       case _ => // tags and item numbers are equal, check next
     }
@@ -84,160 +71,35 @@ sealed trait TagPath {
   override def equals(that: Any): Boolean = (this, that) match {
     case (p1: TagPath, p2: TagPath) if p1.isEmpty && p2.isEmpty => true
     case (p1: TagPathTag, p2: TagPathTag) => p1.tag == p2.tag && p1.previous == p2.previous
-    case (p1: TagPathSequenceItem, p2: TagPathSequenceItem) => p1.tag == p2.tag && p1.item == p2.item && p1.previous == p2.previous
-    case (p1: TagPathSequenceAny, p2: TagPathSequenceAny) => p1.tag == p2.tag && p1.previous == p2.previous
+    case (p1: TagPathSequence, p2: TagPathSequence) => p1.tag == p2.tag && p1.previous == p2.previous
+    case (p1: TagPathSequenceEnd, p2: TagPathSequenceEnd) => p1.tag == p2.tag && p1.previous == p2.previous
+    case (p1: TagPathItem, p2: TagPathItem) => p1.tag == p2.tag && p1.item == p2.item && p1.previous == p2.previous
+    case (p1: TagPathItemEnd, p2: TagPathItemEnd) => p1.tag == p2.tag && p1.item == p2.item && p1.previous == p2.previous
     case _ => false
   }
 
-  /**
-    * @param tag tag number
-    * @return `true` if this tag path contains the input tag number
-    * @example (0008,9215)[*].(0010,0010) contains 0x00089215
-    * @example (0008,9215)[*].(0010,0010) contains 0x00100010
-    * @example (0008,9215)[*].(0010,0010) does not contain 0x00100020
-    */
-  def contains(tag: Int): Boolean = toList.map(_.tag).contains(tag)
-
-  /**
-    * A super-path of another path is a path of equal depth with the same sequence of tag numbers. Differences are in the
-    * specification of items. A path with a less restrictive specification of items (wildcard/all
-    * items instead of item index) is said to be a super-path of the more general path.
-    *
-    * The input path is a super-path of this path if and only if this path is a sub-path of the input path.
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a super-path of this path
-    * @example (0008,9215)[1].(0010,0010) is a super-path of (0008,9215)[1].(0010,0010)
-    * @example (0008,9215)[*].(0010,0010) is a super-path of (0008,9215)[1].(0010,0010)
-    * @example (0008,9215)[1].(0010,0010) is not a super-path of (0008,9215)[*].(0010,0010) (it is a sub-path)
-    */
-  def hasSuperPath(that: TagPath): Boolean = (this, that) match {
-    case (EmptyTagPath, EmptyTagPath) => true
-    case (p1: TagPathTag, p2: TagPathTag) => p1.tag == p2.tag && p1.previous.hasSuperPath(p2.previous)
-    case (p1: TagPathSequenceItem, p2: TagPathSequenceItem) => p1.item == p2.item && p1.tag == p2.tag && p1.previous.hasSuperPath(p2.previous)
-    case (p1: TagPathSequenceItem, p2: TagPathSequenceAny) => p1.tag == p2.tag && p1.previous.hasSuperPath(p2.previous)
-    case (p1: TagPathSequenceAny, p2: TagPathSequenceAny) => p1.tag == p2.tag && p1.previous.hasSuperPath(p2.previous)
-    case _ => false
-  }
-
-  /**
-    * A sub-path of another path is a path of equal length with the same sequence of tag numbers. Differences are in the
-    * specification of items. A path with a more restrictive specification of items (item index instead of wildcard/all
-    * items) is said to be a sub-path of the more general path.
-    *
-    * The input path is a sub-path of this path if and only if this path is a super-path of the input path.
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a sub-path of this path
-    * @example (0008,9215)[1].(0010,0010) is a sub-path of (0008,9215)[1].(0010,0010)
-    * @example (0008,9215)[1].(0010,0010) is a sub-path of (0008,9215)[*].(0010,0010)
-    * @example (0008,9215)[*].(0010,0010) is not a sub-path of (0008,9215)[1].(0010,0010) (it is a super-path)
-    */
-  def hasSubPath(that: TagPath): Boolean = that.hasSuperPath(this)
-
-  private[TagPath] def startsWith(that: TagPath,
-                                  f1: (TagPathSequenceItem, TagPathSequenceAny) => Boolean,
-                                  f2: (TagPathSequenceAny, TagPathSequenceItem) => Boolean): Boolean = {
+  def startsWith(that: TagPath): Boolean = {
     if (this.depth >= that.depth)
       this.toList.zip(that.toList).forall {
-        case (thisSeq: TagPathSequenceAny, thatSeq: TagPathSequenceAny) => thisSeq.tag == thatSeq.tag
-        case (thisSeq: TagPathSequenceItem, thatSeq: TagPathSequenceAny) => f1(thisSeq, thatSeq)
-        case (thisSeq: TagPathSequenceAny, thatSeq: TagPathSequenceItem) => f2(thisSeq, thatSeq)
-        case (thisSeq: TagPathSequenceItem, thatSeq: TagPathSequenceItem) => thisSeq.tag == thatSeq.tag && thisSeq.item == thatSeq.item
+        case (thisSeq: TagPathItem, thatSeq: TagPathItem) => thisSeq.tag == thatSeq.tag && thisSeq.item == thatSeq.item
         case (thisTag: TagPathTag, thatTag: TagPathTag) => thisTag.tag == thatTag.tag
         case _ => false
       }
     else
       false
   }
-  /**
-    * Tests if the n first nodes of this path is equal (see definition of `equels`) to the input path of depth n
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is equal to the the start of this tag path
-    */
-  def startsWith(that: TagPath): Boolean = startsWith(that, (_, _) => false, (_, _) => false)
 
-  /**
-    * Tests if the input path of depth n is a sub-path (see definition of `hasSubPath`) of the n first nodes of this path
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a sub-path of the start of this tag path
-    */
-  def startsWithSubPath(that: TagPath): Boolean = startsWith(that, (_, _) => false, (s1, s2) => s1.tag == s2.tag)
-
-  /**
-    * Tests if the input path of depth n is a super-path (see definition of `hasSuperPath`) of the n first nodes of this path
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a super-path of the start of this tag path
-    */
-  def startsWithSuperPath(that: TagPath): Boolean = startsWith(that, (s1, s2) => s1.tag == s2.tag, (_, _) => false)
-
-  private[TagPath] def endsWith(that: TagPath,
-                                f1: (TagPathSequenceItem, TagPathSequenceAny) => Boolean,
-                                f2: (TagPathSequenceAny, TagPathSequenceItem) => Boolean): Boolean =
+  def endsWith(that: TagPath): Boolean =
     ((this, that) match {
       case (EmptyTagPath, EmptyTagPath) => true
-      case (thisSeq: TagPathSequenceAny, thatSeq: TagPathSequenceAny) => thisSeq.tag == thatSeq.tag
-      case (thisSeq: TagPathSequenceItem, thatSeq: TagPathSequenceAny) => f1(thisSeq, thatSeq)
-      case (thisSeq: TagPathSequenceAny, thatSeq: TagPathSequenceItem) => f2(thisSeq, thatSeq)
-      case (thisSeq: TagPathSequenceItem, thatSeq: TagPathSequenceItem) => thisSeq.tag == thatSeq.tag && thisSeq.item == thatSeq.item
+      case (thisSeq: TagPathItem, thatSeq: TagPathItem) => thisSeq.tag == thatSeq.tag && thisSeq.item == thatSeq.item
       case (thisTag: TagPathTag, thatTag: TagPathTag) => thisTag.tag == thatTag.tag
       case _ => false
     }) && ((this.previous, that.previous) match {
       case (_, EmptyTagPath) => true
       case (EmptyTagPath, _) => false
-      case (thisPrev, thatPrev) => thisPrev.endsWith(thatPrev, f1, f2)
+      case (thisPrev, thatPrev) => thisPrev.endsWith(thatPrev)
     })
-
-  /**
-    * Tests if the n last nodes of this path is equal (see definition of `equels`) to the input path of depth n
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is equal to the end of this tag path
-    */
-  def endsWith(that: TagPath): Boolean = endsWith(that, (_, _) => false, (_, _) => false)
-
-  /**
-    * Tests if the input path of depth n is a sub-path (see definition of `hasSubPath`) of the n last nodes of this path
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a sub-path of the end of this tag path
-    */
-  def endsWithSubPath(that: TagPath): Boolean = endsWith(that, (_, _) => false, (s1, s2) => s1.tag == s2.tag)
-
-  /**
-    * Tests if the input path of depth n is a super-path (see definition of `hasSuperPath`) of the n last nodes of this path
-    *
-    * @param that tag path to test
-    * @return `true` if the input tag path is a super-path of the end of this tag path
-    */
-  def endsWithSuperPath(that: TagPath): Boolean = endsWith(that, (s1, s2) => s1.tag == s2.tag, (_, _) => false)
-
-  /**
-    * Depth of this tag path. A tag path that points to a tag in a sequence in a sequence has depth 3. A tag path that
-    * points to a tag in the root dataset has depth 1. Empty paths have depth 0.
-    *
-    * @return the depth of this tag path, counting from 0
-    */
-  def depth: Int = {
-    @tailrec
-    def depth(path: TagPath, d: Int): Int = if (path.isRoot) d else depth(path.previous, d + 1)
-
-    if (isEmpty) 0 else depth(this, 1)
-  }
-
-  /**
-    * @return the root (left-most) element of this tag path
-    */
-  def head: TagPath = take(1)
-
-  /**
-    * @return the tag path following the root element, that is, all elements to the right of the root element. Returns
-    *         empty path if there are no such elements.
-    */
-  def tail: TagPath = drop(1)
 
   /**
     * Drop n steps of this path from the left
@@ -252,15 +114,19 @@ sealed trait TagPath {
       else if (i == 0)
         path match {
           case EmptyTagPath => EmptyTagPath
-          case p: TagPathSequenceAny => TagPath.fromSequence(p.tag)
-          case p: TagPathSequenceItem => TagPath.fromSequence(p.tag, p.item)
+          case p: TagPathItem => TagPath.fromItem(p.tag, p.item)
+          case p: TagPathItemEnd => TagPath.fromItemEnd(p.tag, p.item)
+          case p: TagPathSequence => TagPath.fromSequence(p.tag)
+          case p: TagPathSequenceEnd => TagPath.fromSequenceEnd(p.tag)
           case p => TagPath.fromTag(p.tag)
         }
       else
         drop(path.previous, i - 1) match {
           case p: TagPathTrunk => path match {
-            case ps: TagPathSequenceAny => p.thenSequence(ps.tag)
-            case pi: TagPathSequenceItem => p.thenSequence(pi.tag, pi.item)
+            case pi: TagPathItem => p.thenItem(pi.tag, pi.item)
+            case pi: TagPathItemEnd => p.thenItemEnd(pi.tag, pi.item)
+            case pi: TagPathSequence => p.thenSequence(pi.tag)
+            case pi: TagPathSequenceEnd => p.thenSequenceEnd(pi.tag)
             case pt: TagPathTag => p.thenTag(pt.tag)
             case _ => EmptyTagPath
           }
@@ -268,20 +134,6 @@ sealed trait TagPath {
         }
 
     drop(path = this, i = depth - n - 1)
-  }
-
-  /**
-    * The first n steps of this path, counted from the left
-    *
-    * @param n the number of steps to take, counted from the left-most root path
-    * @return a new TagPath
-    */
-  def take(n: Int): TagPath = {
-    @tailrec
-    def take(path: TagPath, i: Int): TagPath =
-      if (i <= 0) path else take(path.previous, i - 1)
-
-    take(path = this, i = depth - n)
   }
 
   def toString(lookup: Boolean): String = {
@@ -295,8 +147,8 @@ sealed trait TagPath {
     @tailrec
     def toTagPathString(path: TagPath, tail: String): String = {
       val itemIndexSuffix = path match {
-        case _: TagPathSequenceAny => "[*]"
-        case s: TagPathSequenceItem => s"[${s.item}]"
+        case s: TagPathItem => s"[${s.item}]"
+        case s: TagPathItemEnd => s"[${s.item}]"
         case _ => ""
       }
       val head = toTagString(path.tag) + itemIndexSuffix
@@ -307,16 +159,20 @@ sealed trait TagPath {
     if (isEmpty) "<empty path>" else toTagPathString(path = this, tail = "")
   }
 
-  override def toString: String = toString(lookup = true)
-
   override def hashCode(): Int = this match {
     case EmptyTagPath => 0
-    case s: TagPathSequenceItem => 31 * (31 * (31 * previous.hashCode() + tag.hashCode()) * s.item.hashCode())
+    case s: TagPathItem => 31 * (31 * (31 * previous.hashCode() + tag.hashCode()) * s.item.hashCode())
+    case s: TagPathItemEnd => 31 * (31 * (31 * previous.hashCode() + tag.hashCode()) * s.item.hashCode())
     case _ => 31 * (31 * previous.hashCode() + tag.hashCode())
   }
 }
 
 object TagPath {
+
+
+  trait ItemIndex {
+    val item: Int
+  }
 
   /**
     * A tag path that points to a non-sequence tag
@@ -326,8 +182,63 @@ object TagPath {
     */
   class TagPathTag private[TagPath](val tag: Int, val previous: TagPathTrunk) extends TagPath
 
+  object TagPathTag {
+
+    /**
+      * Parse the string representation of a tag path into a tag path object. Tag paths can either be specified using tag
+      * numbers or their corresponding keywords.
+      *
+      * Examples: (0008,9215)[1].(0010,0010) = DerivationCodeSequence[1].(0010,0010) = (0008,9215)[1].PatientName =
+      * DerivationCodeSequence[1].PatientName
+      *
+      * @param s string to parse
+      * @return a tag path
+      * @throws IllegalArgumentException for malformed input
+      */
+    def parse(s: String): TagPathTag = {
+      def indexPart(s: String): String = s.substring(s.lastIndexOf('[') + 1, s.length - 1)
+
+      def tagPart(s: String): String = s.substring(0, s.indexOf('['))
+
+      def parseTag(s: String): Int = try Integer.parseInt(s.substring(1, 5) + s.substring(6, 10), 16) catch {
+        case _: Throwable =>
+          Dictionary.tagOf(s)
+      }
+
+      def parseIndex(s: String): Int = Integer.parseInt(s)
+
+      def createTag(s: String): TagPathTag = TagPath.fromTag(parseTag(s))
+
+      def addTag(s: String, path: TagPathTrunk): TagPathTag = path.thenTag(parseTag(s))
+
+      def createSeq(s: String): TagPathTrunk = TagPath.fromItem(parseTag(tagPart(s)), parseIndex(indexPart(s)))
+
+      def addSeq(s: String, path: TagPathTrunk): TagPathTrunk = path.thenItem(parseTag(tagPart(s)), parseIndex(indexPart(s)))
+
+      val tags = if (s.indexOf('.') > 0) s.split("\\.").toList else List(s)
+      val seqTags = if (tags.length > 1) tags.init else Nil // list of sequence tags, if any
+      val lastTag = tags.last // tag or sequence
+      try
+        seqTags.headOption
+          .map(first => seqTags.tail.foldLeft(createSeq(first))((path, tag) => addSeq(tag, path)))
+          .map(path => addTag(lastTag, path))
+          .getOrElse(createTag(lastTag))
+      catch {
+        case e: Exception => throw new IllegalArgumentException("Tag path could not be parsed", e)
+      }
+    }
+  }
+
+  class TagPathSequence private[TagPath](val tag: Int, val previous: TagPathTrunk) extends TagPath
+
+  class TagPathSequenceEnd private[TagPath](val tag: Int, val previous: TagPathTrunk) extends TagPath
+
+  class TagPathItem private[TagPath](val tag: Int, val item: Int, val previous: TagPathTrunk) extends TagPathTrunk with ItemIndex
+
+  class TagPathItemEnd private[TagPath](val tag: Int, val item: Int, val previous: TagPathTrunk) extends TagPath with ItemIndex
+
   /**
-    * A tag path that points to a sequence (all items or specific item), or the empty tag path
+    * A tag path that points to a sequence, or the empty tag path
     */
   trait TagPathTrunk extends TagPath {
 
@@ -345,34 +256,14 @@ object TagPath {
       * @param tag tag number
       * @return the tag path
       */
-    def thenSequence(tag: Int) = new TagPathSequenceAny(tag, this)
+    def thenSequence(tag: Int) = new TagPathSequence(tag, this)
 
-    /**
-      * Path to a specific item within a sequence
-      *
-      * @param tag  tag number
-      * @param item item index
-      * @return the tag path
-      */
-    def thenSequence(tag: Int, item: Int) = new TagPathSequenceItem(tag, item, this)
+    def thenSequenceEnd(tag: Int) = new TagPathSequenceEnd(tag, this)
+
+    def thenItem(tag: Int, item: Int) = new TagPathItem(tag, item, this)
+
+    def thenItemEnd(tag: Int, item: Int) = new TagPathItemEnd(tag, item, this)
   }
-
-  /**
-    * A tag path that points to all items of a sequence
-    *
-    * @param tag      the sequence tag number
-    * @param previous a link to the part of this tag part to the left of this tag
-    */
-  class TagPathSequenceAny private[TagPath](val tag: Int, val previous: TagPathTrunk) extends TagPathTrunk
-
-  /**
-    * A tag path that points to an item in a sequence
-    *
-    * @param tag      the sequence tag number
-    * @param item     defines the item index in the sequence
-    * @param previous a link to the part of this tag part to the left of this tag
-    */
-  class TagPathSequenceItem private[TagPath](val tag: Int, val item: Int, val previous: TagPathTrunk) extends TagPathTrunk
 
   /**
     * Empty tag path
@@ -391,71 +282,17 @@ object TagPath {
   def fromTag(tag: Int): TagPathTag = EmptyTagPath.thenTag(tag)
 
   /**
-    * Create a path to all items in a sequence
+    * Create a path to a specific item within a sequence
     *
     * @param tag tag number
     * @return the tag path
     */
-  def fromSequence(tag: Int): TagPathSequenceAny = EmptyTagPath.thenSequence(tag)
+  def fromSequence(tag: Int): TagPathSequence = EmptyTagPath.thenSequence(tag)
 
-  /**
-    * Create a path to a specific item within a sequence
-    *
-    * @param tag  tag number
-    * @param item item index
-    * @return the tag path
-    */
-  def fromSequence(tag: Int, item: Int): TagPathSequenceItem = EmptyTagPath.thenSequence(tag, item)
+  def fromItem(tag: Int, item: Int): TagPathItem = EmptyTagPath.thenItem(tag, item)
 
-  /**
-    * Parse the string representation of a tag path into a tag path object. Tag paths can either be specified using tag
-    * numbers or their corresponding keywords.
-    *
-    * Examples: (0008,9215)[1].(0010,0010) = DerivationCodeSequence[1].(0010,0010) = (0008,9215)[1].PatientName =
-    * DerivationCodeSequence[1].PatientName
-    *
-    * @param s string to parse
-    * @return a tag path
-    * @throws IllegalArgumentException for malformed input
-    */
-  def parse(s: String): TagPath = {
-    def isSeq(s: String): Boolean = s.last == ']'
+  def fromItemEnd(tag: Int, item: Int): TagPathItemEnd = EmptyTagPath.thenItemEnd(tag, item)
 
-    def indexPart(s: String): String = s.substring(s.lastIndexOf('[') + 1, s.length - 1)
-
-    def tagPart(s: String): String = s.substring(0, s.indexOf('['))
-
-    def parseTag(s: String): Int = try Integer.parseInt(s.substring(1, 5) + s.substring(6, 10), 16) catch {
-      case _: Throwable =>
-        Dictionary.tagOf(s)
-    }
-
-    def parseIndex(s: String): Option[Int] = if (s == "*") None else Some(Integer.parseInt(s))
-
-    def createTag(s: String): TagPathTag = TagPath.fromTag(parseTag(s))
-
-    def addTag(s: String, path: TagPathTrunk): TagPathTag = path.thenTag(parseTag(s))
-
-    def createSeq(s: String): TagPathTrunk = parseIndex(indexPart(s))
-      .map(index => TagPath.fromSequence(parseTag(tagPart(s)), index))
-      .getOrElse(TagPath.fromSequence(parseTag(tagPart(s))))
-
-    def addSeq(s: String, path: TagPathTrunk): TagPathTrunk = parseIndex(indexPart(s))
-      .map(index => path.thenSequence(parseTag(tagPart(s)), index))
-      .getOrElse(path.thenSequence(parseTag(tagPart(s))))
-
-
-    val tags = if (s.indexOf('.') > 0) s.split("\\.").toList else List(s)
-    val seqTags = if (tags.length > 1) tags.init else Nil // list of sequence tags, if any
-    val lastTag = tags.last // tag or sequence
-    try {
-      seqTags.headOption.map(first => seqTags.tail.foldLeft(createSeq(first))((path, tag) => addSeq(tag, path))) match {
-        case Some(path) => if (isSeq(lastTag)) addSeq(lastTag, path) else addTag(lastTag, path)
-        case None => if (isSeq(lastTag)) createSeq(lastTag) else createTag(lastTag)
-      }
-    } catch {
-      case e: Exception => throw new IllegalArgumentException("Tag path could not be parsed", e)
-    }
-  }
+  def fromSequenceEnd(tag: Int): TagPathSequenceEnd = EmptyTagPath.thenSequenceEnd(tag)
 
 }

--- a/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
@@ -2,6 +2,9 @@ package se.nimsa.dicom.data
 
 import scala.annotation.tailrec
 
+/**
+  * Common functionality in tag path-like constructs such as TagPath itself and TagTree
+  */
 trait TagPathLike {
 
   type P <: TagPathLike
@@ -10,16 +13,32 @@ trait TagPathLike {
 
   protected val empty: E
 
+  /**
+    * @return tag value at this position of the tag path
+    */
   def tag: Int
+
+  /**
+    * @return link to previous position along this tag path. If current position is at the root, the previous tag path
+    *         is the empty tag path.
+    */
   def previous: T
 
   /**
-    * `true` if this tag path points to the root dataset, at depth 0
+    * `true` if this tag path points to the root dataset, at depth 1
     */
   lazy val isRoot: Boolean = previous.isEmpty
 
+  /**
+    * `true` if this is the empty tag path
+    */
   lazy val isEmpty: Boolean = this eq empty
 
+  /**
+    * Decompose the linked-list tag path structure to a regular list of tag paths ordered from root to leaf
+    *
+    * @return a List of tag paths
+    */
   def toList: List[P] = {
     @tailrec
     def toList(path: P, tail: List[P]): List[P] =
@@ -41,7 +60,7 @@ trait TagPathLike {
     * Depth of this tag path. A tag path that points to a tag in a sequence in a sequence has depth 3. A tag path that
     * points to a tag in the root dataset has depth 1. Empty paths have depth 0.
     *
-    * @return the depth of this tag path, counting from 0
+    * @return the depth of this tag path, counting from 1
     */
   def depth: Int = {
     @tailrec
@@ -83,12 +102,14 @@ trait TagPathLike {
     */
   def drop(n: Int): P
 
+  /**
+    * Create a string representation of this tag path
+    *
+    * @param lookup if `true`, tag numbers will be replaced by keywords if found in the dictionary
+    * @return a string representation of this tag path
+    */
   def toString(lookup: Boolean): String
 
   override def toString: String = toString(lookup = true)
-
-}
-
-object TagPathLike {
 
 }

--- a/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
@@ -1,0 +1,94 @@
+package se.nimsa.dicom.data
+
+import scala.annotation.tailrec
+
+trait TagPathLike {
+
+  type P <: TagPathLike
+  type T <: P
+  type E <: T
+
+  protected val empty: E
+
+  def tag: Int
+  def previous: T
+
+  /**
+    * `true` if this tag path points to the root dataset, at depth 0
+    */
+  lazy val isRoot: Boolean = previous.isEmpty
+
+  lazy val isEmpty: Boolean = this eq empty
+
+  def toList: List[P] = {
+    @tailrec
+    def toList(path: P, tail: List[P]): List[P] =
+      if (path.isRoot) path :: tail else toList(path.previous.asInstanceOf[P], path :: tail)
+
+    if (isEmpty) Nil else toList(this.asInstanceOf[P], Nil)
+  }
+
+  /**
+    * @param tag tag number
+    * @return `true` if this tag path contains the input tag number
+    * @example (0008,9215)[*].(0010,0010) contains 0x00089215
+    * @example (0008,9215)[*].(0010,0010) contains 0x00100010
+    * @example (0008,9215)[*].(0010,0010) does not contain 0x00100020
+    */
+  def contains(tag: Int): Boolean = toList.map(_.tag).contains(tag)
+
+  /**
+    * Depth of this tag path. A tag path that points to a tag in a sequence in a sequence has depth 3. A tag path that
+    * points to a tag in the root dataset has depth 1. Empty paths have depth 0.
+    *
+    * @return the depth of this tag path, counting from 0
+    */
+  def depth: Int = {
+    @tailrec
+    def depth(path: P, d: Int): Int = if (path.isRoot) d else depth(path.previous.asInstanceOf[P], d + 1)
+
+    if (isEmpty) 0 else depth(this.asInstanceOf[P], 1)
+  }
+
+  /**
+    * @return the root (left-most) element of this tag path
+    */
+  def head: P = take(1)
+
+  /**
+    * @return the tag path following the root element, that is, all elements to the right of the root element. Returns
+    *         empty path if there are no such elements.
+    */
+  def tail: P = drop(1)
+
+  /**
+    * The first n steps of this path, counted from the left
+    *
+    * @param n the number of steps to take, counted from the left-most root path
+    * @return a new TagPath
+    */
+  def take(n: Int): P = {
+    @tailrec
+    def take(path: P, i: Int): P =
+      if (i <= 0) path else take(path.previous.asInstanceOf[P], i - 1)
+
+    take(path = this.asInstanceOf[P], i = depth - n)
+  }
+
+  /**
+    * Drop n steps of this path from the left
+    *
+    * @param n the number of steps to omit, counted from the lef-most root path
+    * @return a new TagPath
+    */
+  def drop(n: Int): P
+
+  def toString(lookup: Boolean): String
+
+  override def toString: String = toString(lookup = true)
+
+}
+
+object TagPathLike {
+
+}

--- a/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagPathLike.scala
@@ -44,7 +44,7 @@ trait TagPathLike {
     def toList(path: P, tail: List[P]): List[P] =
       if (path.isRoot) path :: tail else toList(path.previous.asInstanceOf[P], path :: tail)
 
-    if (isEmpty) Nil else toList(this.asInstanceOf[P], Nil)
+    toList(this.asInstanceOf[P], Nil)
   }
 
   /**

--- a/src/main/scala/se/nimsa/dicom/data/TagTree.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagTree.scala
@@ -25,8 +25,8 @@ import scala.annotation.tailrec
   * Representation of a tag path with support for pointing to all items in sequences, thus forming a tree of tag paths.
   *
   * The nomenclature of tag trees is as follows. The left-most node is called the <i>root</i>. The right-most node is a
-  * <i>leaf</i>. A path extending from a root to a leaf is called a <i>branch</i>. A path starting at the root and
-  * extends to some point in the tree, not necessarily a leaf, is called a <i>trunk</i>. A path starting from any point
+  * <i>leaf</i>. A branch extending from a root to a leaf is a <i>path</i>. A branch starting at the root and
+  * extends to some point in the tree, not necessarily a leaf, is called a <i>trunk</i>. A branch starting from any point
   * in the tree and extends to a leaf is called a <i>twig</i>.
   */
 sealed trait TagTree extends TagPathLike {
@@ -71,18 +71,18 @@ sealed trait TagTree extends TagPathLike {
 
   /**
     * @param tagPath tag path to test
-    * @return `true` if the input tag path is a branch (from root to leaf) of this tree
-    * @example (0008,9215)[1].(0010,0010) is a branch of (0008,9215)[*].(0010,0010)
-    * @example (0008,9215)[1] is not a branch of (0008,9215)[*].(0010,0010)
-    * @example the empty tag path is a branch of the empty tag tree
+    * @return `true` if the input tag path is a path from root to leaf in this tree
+    * @example (0008,9215)[1].(0010,0010) is a path in (0008,9215)[*].(0010,0010)
+    * @example (0008,9215)[1] is not a path in (0008,9215)[*].(0010,0010)
+    * @example the empty tag path is a path in the empty tag tree
     */
-  def hasBranch(tagPath: TagPath): Boolean = (this, tagPath) match {
+  def hasPath(tagPath: TagPath): Boolean = (this, tagPath) match {
     case (EmptyTagTree, EmptyTagPath) => true
-    case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag && t.previous.hasBranch(p.previous)
-    case (t: TagTreeItem, p: TagPath with ItemIndex) => t.item == p.item && t.tag == p.tag && t.previous.hasBranch(p.previous)
-    case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.previous.hasBranch(p.previous)
-    case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag && t.previous.hasBranch(p.previous)
-    case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag && t.previous.hasPath(p.previous)
+    case (t: TagTreeItem, p: TagPath with ItemIndex) => t.item == p.item && t.tag == p.tag && t.previous.hasPath(p.previous)
+    case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.previous.hasPath(p.previous)
+    case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag && t.previous.hasPath(p.previous)
+    case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag && t.previous.hasPath(p.previous)
     case _ => false
   }
 
@@ -111,7 +111,7 @@ sealed trait TagTree extends TagPathLike {
 
   /**
     * @param tagPath tag path to test
-    * @return `true` if any branch of this tree is a trunk (the start of) the input tag path
+    * @return `true` if any path of this tree is equal to or the start of the input tag path
     * @example (0008,9215)[1].(0010,0010) has trunk (0008,9215)[1].(0010,0010)
     * @example (0008,9215)[1].(0010,0010) has trunk (0008,9215)[*].(0010,0010)
     * @example (0008,9215)[1].(0010,0010) has trunk (0008,9215)[*]
@@ -296,7 +296,7 @@ object TagTree {
     * Create a tag tree from a tag path
     *
     * @param tagPath input tag path
-    * @return the equivalent (branch-shaped) tag tree
+    * @return the equivalent (path-shaped) tag tree
     */
   def fromPath(tagPath: TagPath): TagTree = {
     val root = tagPath.head match {

--- a/src/main/scala/se/nimsa/dicom/data/TagTree.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagTree.scala
@@ -278,6 +278,31 @@ object TagTree {
   def fromItem(tag: Int, item: Int): TagTreeItem = EmptyTagTree.thenItem(tag, item)
 
   /**
+    * Create a tag tree from a tag path
+    *
+    * @param tagPath input tag path
+    * @return the equivalent (branch-shaped) tag tree
+    */
+  def fromPath(tagPath: TagPath): TagTree = {
+    val root = tagPath.head match {
+      case p: TagPathTag => TagTree.fromTag(p.tag)
+      case p: TagPathItem => TagTree.fromItem(p.tag, p.item)
+      case p: TagPathItemEnd => TagTree.fromItem(p.tag, p.item)
+      case p: TagPathSequence => TagTree.fromAnyItem(p.tag)
+      case p: TagPathSequenceEnd => TagTree.fromAnyItem(p.tag)
+      case _ => EmptyTagTree
+    }
+    tagPath.drop(1).toList.foldLeft(root) {
+      case (t: TagTreeTrunk, p: TagPathTag) => t.thenTag(p.tag)
+      case (t: TagTreeTrunk, p: TagPathItem) => t.thenItem(p.tag, p.item)
+      case (t: TagTreeTrunk, p: TagPathItemEnd) => t.thenItem(p.tag, p.item)
+      case (t: TagTreeTrunk, p: TagPathSequence) => t.thenAnyItem(p.tag)
+      case (t: TagTreeTrunk, p: TagPathSequenceEnd) => t.thenAnyItem(p.tag)
+      case (t, _) => t
+    }
+  }
+
+  /**
     * Parse the string representation of a tag tree into a tag tree object. Tag trees can either be specified using tag
     * numbers or their corresponding keywords.
     *

--- a/src/main/scala/se/nimsa/dicom/data/TagTree.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagTree.scala
@@ -88,6 +88,7 @@ sealed trait TagTree extends TagPathLike {
 
   private def matchTrunk(that: TagPath): Boolean =
     this.toList.zip(that.toList).forall {
+      case (_, EmptyTagPath) => true
       case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
       case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
       case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag

--- a/src/main/scala/se/nimsa/dicom/data/TagTree.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagTree.scala
@@ -1,0 +1,309 @@
+/*
+ * Copyright 2018 Lars Edenbrandt
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package se.nimsa.dicom.data
+
+import se.nimsa.dicom.data.TagPath._
+import se.nimsa.dicom.data.TagTree._
+
+import scala.annotation.tailrec
+
+sealed trait TagTree extends TagPathLike {
+
+  override type P = TagTree
+  override type T = TagTreeTrunk
+  override type E = EmptyTagTree.type
+
+  override protected val empty: E = EmptyTagTree
+
+  def tag: Int
+
+  /**
+    * @param that tag path to test
+    * @return `true` if the input tag path is equal to this tag path. TagTree nodes are compared pairwise from the end
+    *         towards the start of the paths. Node types, tag numbers as well as item indices where applicable must be
+    *         equal. Paths of different lengths cannot be equal.
+    * @example (0010,0010) == (0010,0010)
+    * @example (0010,0010) != (0010,0020)
+    * @example (0010,0010) != (0008,9215)[1].(0010,0010)
+    * @example (0008,9215)[*].(0010,0010) != (0008,9215)[1].(0010,0010)
+    * @example (0008,9215)[3].(0010,0010) == (0008,9215)[3].(0010,0010)
+    */
+  override def equals(that: Any): Boolean = (this, that) match {
+    case (t: TagTree, p: TagTree) if t.isEmpty && p.isEmpty => true
+    case (t: TagTreeTag, p: TagTreeTag) => t.tag == p.tag && t.previous == p.previous
+    case (t: TagTreeItem, p: TagTreeItem) => t.tag == p.tag && t.item == p.item && t.previous == p.previous
+    case (t: TagTreeAnyItem, p: TagTreeAnyItem) => t.tag == p.tag && t.previous == p.previous
+    case _ => false
+  }
+
+  def isPath: Boolean = this match {
+    case EmptyTagTree => true
+    case _: TagTreeAnyItem => false
+    case t => t.previous.isPath
+  }
+
+  def hasBranch(tagPath: TagPath): Boolean = (this, tagPath) match {
+    case (EmptyTagTree, EmptyTagPath) => true
+    case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeItem, p: TagPath with ItemIndex) => t.item == p.item && t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeItem, p: TagPathSequence) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeItem, p: TagPathSequenceEnd) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag && t.previous.hasBranch(p.previous)
+    case _ => false
+  }
+
+  private def matchTrunk(that: TagPath): Boolean =
+    this.toList.zip(that.toList).forall {
+      case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
+      case (t: TagTreeItem, p: TagPathSequence) => t.tag == p.tag
+      case (t: TagTreeItem, p: TagPathSequenceEnd) => t.tag == p.tag
+      case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
+      case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag
+      case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag
+      case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag
+      case _ => false
+    }
+
+  def hasTrunk(tagPath: TagPath): Boolean = if (this.depth >= tagPath.depth) matchTrunk(tagPath) else false
+
+  def isTrunkOf(tagPath: TagPath): Boolean = if (this.depth <= tagPath.depth) matchTrunk(tagPath) else false
+
+  def hasTwig(tagPath: TagPath): Boolean =
+    ((this, tagPath) match {
+      case (EmptyTagTree, EmptyTagPath) => true
+      case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
+      case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag
+      case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag
+      case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
+      case (t: TagTreeItem, p: TagPathSequence) => t.tag == p.tag
+      case (t: TagTreeItem, p: TagPathSequenceEnd) => t.tag == p.tag
+      case (t: TagPathTag, p: TagPathTag) => t.tag == p.tag
+      case _ => false
+    }) && ((this.previous, tagPath.previous) match {
+      case (_, EmptyTagPath) => true
+      case (EmptyTagTree, _) => false
+      case (thisPrev, thatPrev) => thisPrev.hasTwig(thatPrev)
+    })
+
+  /**
+    * Drop n steps of this path from the left
+    *
+    * @param n the number of steps to omit, counted from the lef-most root path
+    * @return a new TagPath
+    */
+  def drop(n: Int): TagTree = {
+    def drop(path: TagTree, i: Int): TagTree =
+      if (i < 0)
+        EmptyTagTree
+      else if (i == 0)
+        path match {
+          case EmptyTagTree => EmptyTagTree
+          case p: TagTreeItem => TagTree.fromItem(p.tag, p.item)
+          case p: TagTreeAnyItem => TagTree.fromAnyItem(p.tag)
+          case p => TagTree.fromTag(p.tag)
+        }
+      else
+        drop(path.previous, i - 1) match {
+          case p: TagTreeTrunk => path match {
+            case pi: TagTreeItem => p.thenItem(pi.tag, pi.item)
+            case pi: TagTreeAnyItem => p.thenAnyItem(pi.tag)
+            case pt: TagTreeTag => p.thenTag(pt.tag)
+            case _ => EmptyTagTree
+          }
+          case _ => EmptyTagTree // cannot happen
+        }
+
+    drop(path = this, i = depth - n - 1)
+  }
+
+  def toString(lookup: Boolean): String = {
+    def toTagString(tag: Int): String = if (lookup) {
+      val keyword = Dictionary.keywordOf(tag)
+      if (keyword.isEmpty) tagToString(tag) else keyword
+    }
+    else
+      tagToString(tag)
+
+    @tailrec
+    def toTagTreeString(path: TagTree, tail: String): String = {
+      val itemIndexSuffix = path match {
+        case _: TagTreeAnyItem => "[*]"
+        case s: TagTreeItem => s"[${
+          s.item
+        }]"
+        case _ => ""
+      }
+      val head = toTagString(path.tag) + itemIndexSuffix
+      val part = head + tail
+      if (path.isRoot) part else toTagTreeString(path.previous, "." + part)
+    }
+
+    if (isEmpty) "<empty path>" else toTagTreeString(path = this, tail = "")
+  }
+
+  override def hashCode(): Int = this match {
+    case EmptyTagTree => 0
+    case s: TagTreeItem => 31 * (31 * (31 * previous.hashCode() + tag.hashCode()) * s.item.hashCode())
+    case _ => 31 * (31 * previous.hashCode() + tag.hashCode())
+  }
+}
+
+object TagTree {
+
+  /**
+    * A tag path that points to a non-sequence tag
+    *
+    * @param tag      the tag number
+    * @param previous a link to the part of this tag part to the left of this tag
+    */
+  class TagTreeTag private[TagTree](val tag: Int, val previous: TagTreeTrunk) extends TagTree
+
+  /**
+    * A tag path that points to a sequence (all items or specific item), or the empty tag path
+    */
+  trait TagTreeTrunk extends TagTree {
+
+    /**
+      * Path to a specific tag
+      *
+      * @param tag tag number
+      * @return the tag path
+      */
+    def thenTag(tag: Int) = new TagTreeTag(tag, this)
+
+    /**
+      * Path to all items in a sequence
+      *
+      * @param tag tag number
+      * @return the tag path
+      */
+    def thenAnyItem(tag: Int) = new TagTreeAnyItem(tag, this)
+
+    /**
+      * Path to a specific item within a sequence
+      *
+      * @param tag  tag number
+      * @param item item index
+      * @return the tag path
+      */
+    def thenItem(tag: Int, item: Int) = new TagTreeItem(tag, item, this)
+  }
+
+  /**
+    * A tag path that points to all items of a sequence
+    *
+    * @param tag      the sequence tag number
+    * @param previous a link to the part of this tag part to the left of this tag
+    */
+  class TagTreeAnyItem private[TagTree](val tag: Int, val previous: TagTreeTrunk) extends TagTreeTrunk
+
+  /**
+    * A tag path that points to an item in a sequence
+    *
+    * @param tag      the sequence tag number
+    * @param item     defines the item index in the sequence
+    * @param previous a link to the part of this tag part to the left of this tag
+    */
+  class TagTreeItem private[TagTree](val tag: Int, val item: Int, val previous: TagTreeTrunk) extends TagTreeTrunk
+
+  /**
+    * Empty tag path
+    */
+  object EmptyTagTree extends TagTreeTrunk {
+    def tag: Int = throw new NoSuchElementException("Empty tag path")
+    val previous: TagTreeTrunk = EmptyTagTree
+  }
+
+  /**
+    * Create a path to a specific tag
+    *
+    * @param tag tag number
+    * @return the tag path
+    */
+  def fromTag(tag: Int): TagTreeTag = EmptyTagTree.thenTag(tag)
+
+  /**
+    * Create a path to all items in a sequence
+    *
+    * @param tag tag number
+    * @return the tag path
+    */
+  def fromAnyItem(tag: Int): TagTreeAnyItem = EmptyTagTree.thenAnyItem(tag)
+
+  /**
+    * Create a path to a specific item within a sequence
+    *
+    * @param tag  tag number
+    * @param item item index
+    * @return the tag path
+    */
+  def fromItem(tag: Int, item: Int): TagTreeItem = EmptyTagTree.thenItem(tag, item)
+
+  /**
+    * Parse the string representation of a tag path into a tag path object. Tag paths can either be specified using tag
+    * numbers or their corresponding keywords.
+    *
+    * Examples: (0008,9215)[1].(0010,0010) = DerivationCodeSequence[1].(0010,0010) = (0008,9215)[1].PatientName =
+    * DerivationCodeSequence[1].PatientName
+    *
+    * @param s string to parse
+    * @return a tag path
+    * @throws IllegalArgumentException for malformed input
+    */
+  def parse(s: String): TagTree = {
+    def isSeq(s: String): Boolean = s.last == ']'
+
+    def indexPart(s: String): String = s.substring(s.lastIndexOf('[') + 1, s.length - 1)
+
+    def tagPart(s: String): String = s.substring(0, s.indexOf('['))
+
+    def parseTag(s: String): Int = try Integer.parseInt(s.substring(1, 5) + s.substring(6, 10), 16) catch {
+      case _: Throwable =>
+        Dictionary.tagOf(s)
+    }
+
+    def parseIndex(s: String): Option[Int] = if (s == "*") None else Some(Integer.parseInt(s))
+
+    def createTag(s: String): TagTreeTag = TagTree.fromTag(parseTag(s))
+
+    def addTag(s: String, path: TagTreeTrunk): TagTreeTag = path.thenTag(parseTag(s))
+
+    def createSeq(s: String): TagTreeTrunk = parseIndex(indexPart(s))
+      .map(index => TagTree.fromItem(parseTag(tagPart(s)), index))
+      .getOrElse(TagTree.fromAnyItem(parseTag(tagPart(s))))
+
+    def addSeq(s: String, path: TagTreeTrunk): TagTreeTrunk = parseIndex(indexPart(s))
+      .map(index => path.thenItem(parseTag(tagPart(s)), index))
+      .getOrElse(path.thenAnyItem(parseTag(tagPart(s))))
+
+
+    val tags = if (s.indexOf('.') > 0) s.split("\\.").toList else List(s)
+    val seqTags = if (tags.length > 1) tags.init else Nil // list of sequence tags, if any
+    val lastTag = tags.last // tag or sequence
+    try {
+      seqTags.headOption.map(first => seqTags.tail.foldLeft(createSeq(first))((path, tag) => addSeq(tag, path))) match {
+        case Some(path) => if (isSeq(lastTag)) addSeq(lastTag, path) else addTag(lastTag, path)
+        case None => if (isSeq(lastTag)) createSeq(lastTag) else createTag(lastTag)
+      }
+    } catch {
+      case e: Exception => throw new IllegalArgumentException("Tag path could not be parsed", e)
+    }
+  }
+
+}

--- a/src/main/scala/se/nimsa/dicom/data/TagTree.scala
+++ b/src/main/scala/se/nimsa/dicom/data/TagTree.scala
@@ -86,17 +86,6 @@ sealed trait TagTree extends TagPathLike {
     case _ => false
   }
 
-  private def matchTrunk(that: TagPath): Boolean =
-    this.toList.zip(that.toList).forall {
-      case (_, EmptyTagPath) => true
-      case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
-      case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
-      case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag
-      case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag
-      case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag
-      case _ => false
-    }
-
   /**
     * @param tagPath tag path to test
     * @return `true` if the input tag path is a trunk of this tree
@@ -104,7 +93,21 @@ sealed trait TagTree extends TagPathLike {
     * @example (0008,9215)[1] is a trunk of (0008,9215)[*].(0010,0010)
     * @example (0010,0010) is not a trunk of (0008,9215)[*].(0010,0010)
     */
-  def hasTrunk(tagPath: TagPath): Boolean = if (this.depth >= tagPath.depth) matchTrunk(tagPath) else false
+  def hasTrunk(tagPath: TagPath): Boolean =
+    if (this.depth >= tagPath.depth)
+      this.toList.zip(tagPath.toList).forall {
+        case (_, EmptyTagPath) => true
+        case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
+        case (t: TagTreeItem, p: TagPathSequence) => t.tag == p.tag
+        case (t: TagTreeItem, p: TagPathSequenceEnd) => t.tag == p.tag
+        case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
+        case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag
+        case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag
+        case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag
+        case _ => false
+      }
+    else
+      false
 
   /**
     * @param tagPath tag path to test
@@ -115,7 +118,19 @@ sealed trait TagTree extends TagPathLike {
     * @example (0008,9215)[1].(0010,0010) does not have trunk (0008,9215)[3]
     * @example (0008,9215)[1].(0010,0010) does not have trunk (0010,0010)
     */
-  def isTrunkOf(tagPath: TagPath): Boolean = if (this.depth <= tagPath.depth) matchTrunk(tagPath) else false
+  def isTrunkOf(tagPath: TagPath): Boolean =
+    if (this.depth <= tagPath.depth)
+      this.toList.zip(tagPath.toList).forall {
+        case (_, EmptyTagPath) => true
+        case (t: TagTreeItem, p: TagPath with ItemIndex) => t.tag == p.tag && t.item == p.item
+        case (t: TagTreeAnyItem, p: TagPath with ItemIndex) => t.tag == p.tag
+        case (t: TagTreeAnyItem, p: TagPathSequence) => t.tag == p.tag
+        case (t: TagTreeAnyItem, p: TagPathSequenceEnd) => t.tag == p.tag
+        case (t: TagTreeTag, p: TagPathTag) => t.tag == p.tag
+        case _ => false
+      }
+    else
+      false
 
   /**
     * @param tagPath tag path to test

--- a/src/main/scala/se/nimsa/dicom/streams/CollectFlow.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/CollectFlow.scala
@@ -28,7 +28,7 @@ object CollectFlow {
     */
   def collectFlow(tags: Set[TagPath], label: String, maxBufferSize: Int = 1000000): Flow[DicomPart, DicomPart, NotUsed] = {
     val maxTag = if (tags.isEmpty) 0 else tags.map(_.toList.head.tag).max
-    val tagCondition = (tagPath: TagPath) => tags.exists(tagPath.startsWithSuperPath)
+    val tagCondition = (tagPath: TagPath) => tags.exists(tagPath.startsWith)
     val stopCondition = if (tags.isEmpty)
       (_: TagPath) => true
     else

--- a/src/main/scala/se/nimsa/dicom/streams/DicomFlow.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/DicomFlow.scala
@@ -267,7 +267,7 @@ trait TagPathTracking[Out] extends DicomFlow[Out] with GuaranteedValueEvent[Out]
 
   abstract override def onHeader(part: HeaderPart): List[Out] = {
     tagPath = tagPath match {
-      case t: TagPathSequenceItem => t.thenTag(part.tag)
+      case t: TagPathItem => t.thenTag(part.tag)
       case t => t.previous.thenTag(part.tag)
     }
     super.onHeader(part)
@@ -275,7 +275,7 @@ trait TagPathTracking[Out] extends DicomFlow[Out] with GuaranteedValueEvent[Out]
 
   abstract override def onFragments(part: FragmentsPart): List[Out] = {
     tagPath = tagPath match {
-      case t: TagPathSequenceItem => t.thenTag(part.tag)
+      case t: TagPathItem => t.thenTag(part.tag)
       case t => t.previous.thenTag(part.tag)
     }
     super.onFragments(part)
@@ -283,25 +283,25 @@ trait TagPathTracking[Out] extends DicomFlow[Out] with GuaranteedValueEvent[Out]
 
   abstract override def onSequence(part: SequencePart): List[Out] = {
     tagPath = tagPath match {
-      case t: TagPathSequenceItem => t.thenSequence(part.tag)
+      case t: TagPathItem => t.thenSequence(part.tag)
       case t => t.previous.thenSequence(part.tag)
     }
     super.onSequence(part)
   }
 
   abstract override def onSequenceDelimitation(part: SequenceDelimitationPart): List[Out] = {
-    if (!inFragments) tagPath = tagPath.previous.thenSequence(tagPath.tag)
+    if (!inFragments) tagPath = tagPath.previous.thenSequenceEnd(tagPath.tag)
     super.onSequenceDelimitation(part)
   }
 
   abstract override def onItem(part: ItemPart): List[Out] = {
-      if (!inFragments) tagPath = tagPath.previous.thenSequence(tagPath.tag, part.index)
+      if (!inFragments) tagPath = tagPath.previous.thenItem(tagPath.tag, part.index)
     super.onItem(part)
   }
 
   abstract override def onItemDelimitation(part: ItemDelimitationPart): List[Out] = {
     tagPath = tagPath match {
-      case t: TagPathSequenceItem => tagPath.previous.thenSequence(t.tag, t.item)
+      case t: TagPathItem => tagPath.previous.thenItemEnd(t.tag, t.item)
       case t => t.previous
     }
     super.onItemDelimitation(part)

--- a/src/main/scala/se/nimsa/dicom/streams/DicomFlow.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/DicomFlow.scala
@@ -301,8 +301,11 @@ trait TagPathTracking[Out] extends DicomFlow[Out] with GuaranteedValueEvent[Out]
 
   abstract override def onItemDelimitation(part: ItemDelimitationPart): List[Out] = {
     tagPath = tagPath match {
-      case t: TagPathItem => tagPath.previous.thenItemEnd(t.tag, t.item)
-      case t => t.previous
+      case t: TagPathItem => t.previous.thenItemEnd(t.tag, t.item)
+      case t => t.previous match {
+        case ti: TagPathItem => ti.previous.thenItemEnd(ti.tag, ti.item)
+        case _ => tagPath // should never get delimitation when not inside item
+      }
     }
     super.onItemDelimitation(part)
   }

--- a/src/main/scala/se/nimsa/dicom/streams/ElementFlows.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/ElementFlows.scala
@@ -73,33 +73,33 @@ object ElementFlows {
       () => {
         case e: ValueElement =>
           tagPath = tagPath match {
-            case t: TagPathSequenceItem => t.thenTag(e.tag)
+            case t: TagPathItem => t.thenTag(e.tag)
             case t => t.previous.thenTag(e.tag)
           }
           (tagPath, e) :: Nil
         case e: FragmentsElement =>
           tagPath = tagPath match {
-            case t: TagPathSequenceItem => t.thenTag(e.tag)
+            case t: TagPathItem => t.thenTag(e.tag)
             case t => t.previous.thenTag(e.tag)
           }
           inFragments = true
           (tagPath, e) :: Nil
         case e: SequenceElement =>
           tagPath = tagPath match {
-            case t: TagPathSequenceItem => t.thenSequence(e.tag)
+            case t: TagPathItem => t.thenSequence(e.tag)
             case t => t.previous.thenSequence(e.tag)
           }
           (tagPath, e) :: Nil
         case e: SequenceDelimitationElement =>
-          if (!inFragments) tagPath = tagPath.previous.thenSequence(tagPath.tag)
+          if (!inFragments) tagPath = tagPath.previous.thenSequenceEnd(tagPath.tag)
           inFragments = false
           (tagPath, e) :: Nil
         case e: ItemElement =>
-          if (!inFragments) tagPath = tagPath.previous.thenSequence(tagPath.tag, e.index)
+          if (!inFragments) tagPath = tagPath.previous.thenItem(tagPath.tag, e.index)
           (tagPath, e) :: Nil
         case e: ItemDelimitationElement =>
           tagPath = tagPath match {
-            case t: TagPathSequenceItem => tagPath.previous.thenSequence(t.tag, t.item)
+            case t: TagPathItem => tagPath.previous.thenItemEnd(t.tag, t.item)
             case t => t.previous
           }
           (tagPath, e) :: Nil

--- a/src/main/scala/se/nimsa/dicom/streams/ElementFlows.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/ElementFlows.scala
@@ -99,8 +99,11 @@ object ElementFlows {
           (tagPath, e) :: Nil
         case e: ItemDelimitationElement =>
           tagPath = tagPath match {
-            case t: TagPathItem => tagPath.previous.thenItemEnd(t.tag, t.item)
-            case t => t.previous
+            case t: TagPathItem => t.previous.thenItemEnd(t.tag, t.item)
+            case t => t.previous match {
+              case ti: TagPathItem => ti.previous.thenItemEnd(ti.tag, ti.item)
+              case _ => tagPath // should never get delimitation when not inside item
+            }
           }
           (tagPath, e) :: Nil
         case e =>

--- a/src/main/scala/se/nimsa/dicom/streams/ModifyFlow.scala
+++ b/src/main/scala/se/nimsa/dicom/streams/ModifyFlow.scala
@@ -147,6 +147,16 @@ object ModifyFlow {
           value = ByteString.empty
           Nil
         }
+        .orElse {
+          currentInsertions
+            .find(_.tagPath == tagPath)
+            .map { insertion =>
+              currentHeader = Some(header)
+              currentModification = Some(TagModification(_ == insertion.tagPath, _ => insertion.value))
+              value = ByteString.empty
+              Nil
+            }
+        }
         .getOrElse(header :: Nil)
 
       override def onPart(part: DicomPart): List[DicomPart] =

--- a/src/test/scala/se/nimsa/dicom/data/DictionaryTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/DictionaryTest.scala
@@ -1,0 +1,28 @@
+package se.nimsa.dicom.data
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class DictionaryTest extends FlatSpec with Matchers {
+
+  "The DICOM dictionary" should "support getting the value representation for a tag" in {
+    Dictionary.vrOf(Tag.PatientName) shouldBe VR.PN
+  }
+
+  it should "support getting the multiplicity for a tag" in {
+    Dictionary.vmOf(0x00041141) shouldBe Multiplicity.bounded(1, 8)
+  }
+
+  it should "support getting the keyword for a tag" in {
+    Dictionary.keywordOf(Tag.PatientName) shouldBe "PatientName"
+  }
+
+  it should "support getting the tag for a keyword" in {
+    Dictionary.tagOf("PatientName") shouldBe Tag.PatientName
+  }
+
+  it should "support listing all keywords" in {
+    val keywords = Dictionary.keywords()
+    keywords.length should be > 4000
+    keywords.contains("PatientName") shouldBe true
+  }
+}

--- a/src/test/scala/se/nimsa/dicom/data/MultiplicityTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/MultiplicityTest.scala
@@ -1,0 +1,56 @@
+package se.nimsa.dicom.data
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class MultiplicityTest extends FlatSpec with Matchers {
+
+  "Multiplicity" should "support exactly 1" in {
+    val m = Multiplicity.single
+    m.min shouldBe 1
+    m.max shouldBe Some(1)
+    m.isBounded shouldBe true
+    m.isUnbounded shouldBe false
+    m.isSingle shouldBe true
+    m.isMultiple shouldBe false
+  }
+
+  it should "support fixed multiplicities other than 1" in {
+    val m = Multiplicity.fixed(5)
+    m.min shouldBe 5
+    m.max shouldBe Some(5)
+    m.isBounded shouldBe true
+    m.isUnbounded shouldBe false
+    m.isSingle shouldBe false
+    m.isMultiple shouldBe true
+  }
+
+  it should "support one to many multiplicities" in {
+    val m = Multiplicity.oneToMany
+    m.min shouldBe 1
+    m.max shouldBe None
+    m.isBounded shouldBe false
+    m.isUnbounded shouldBe true
+    m.isSingle shouldBe false
+    m.isMultiple shouldBe true
+  }
+
+  it should "support bounded multiplicities" in {
+    val m = Multiplicity.bounded(2, 5)
+    m.min shouldBe 2
+    m.max shouldBe Some(5)
+    m.isBounded shouldBe true
+    m.isUnbounded shouldBe false
+    m.isSingle shouldBe false
+    m.isMultiple shouldBe true
+  }
+
+  it should "support unbounded multiplicities" in {
+    val m = Multiplicity.unbounded(2)
+    m.min shouldBe 2
+    m.max shouldBe None
+    m.isBounded shouldBe false
+    m.isUnbounded shouldBe true
+    m.isSingle shouldBe false
+    m.isMultiple shouldBe true
+  }
+}

--- a/src/test/scala/se/nimsa/dicom/data/TagPathLikeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagPathLikeTest.scala
@@ -1,0 +1,75 @@
+package se.nimsa.dicom.data
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class TagPathLikeTest extends FlatSpec with Matchers {
+
+  import TagPath._
+
+  "The tag path depth" should "be 1 when pointing to a tag in the root dataset" in {
+    val path = TagPath.fromTag(Tag.PatientID)
+    path.depth shouldBe 1
+  }
+
+  it should "be 0 for empty tag paths" in {
+    EmptyTagPath.depth shouldBe 0
+  }
+
+  it should "be 4 when pointing to a tag in three levels of sequences" in {
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(Tag.DerivationCodeSequence, 3).thenItem(Tag.DerivationCodeSequence, 5).thenTag(Tag.PatientID)
+    path.depth shouldBe 4
+  }
+
+  "A tag path" should "be root when pointing to root dataset" in {
+    val path = TagPath.fromTag(Tag.PatientID)
+    path.isRoot shouldBe true
+  }
+
+  it should "not be root when pointing to a tag in a sequence" in {
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientID)
+    path.isRoot shouldBe false
+  }
+
+  "A list representation of tag path tags" should "contain a single entry for a tag in the root dataset" in {
+    val path = TagPath.fromTag(Tag.PatientID)
+    path.toList shouldBe path :: Nil
+  }
+
+  it should "contain four entries for a path of depth 3" in {
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(Tag.DerivationCodeSequence, 3).thenItem(Tag.DerivationCodeSequence, 2).thenTag(Tag.PatientID)
+    path.toList shouldBe path.previous.previous.previous :: path.previous.previous :: path.previous :: path :: Nil
+  }
+
+  "The contains test" should "return for any tag number on the tag path" in {
+    val path = TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3)
+    path.contains(1) shouldBe true
+    path.contains(2) shouldBe true
+    path.contains(3) shouldBe true
+    path.contains(4) shouldBe false
+  }
+
+  "The take operation" should "preserve elements from the left" in {
+    val path = TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3).thenTag(4)
+    path.take(-100) shouldBe EmptyTagPath
+    path.take(0) shouldBe EmptyTagPath
+    path.take(1) shouldBe TagPath.fromItem(1, 1)
+    path.take(2) shouldBe TagPath.fromItem(1, 1).thenItem(2, 1)
+    path.take(3) shouldBe TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3)
+    path.take(4) shouldBe path
+    path.take(100) shouldBe path
+  }
+
+  "The head of a tag path" should "be the root element of the path" in {
+    TagPath.fromTag(1).head shouldBe TagPath.fromTag(1)
+    TagPath.fromItem(1, 1).head shouldBe TagPath.fromItem(1, 1)
+    TagPath.fromItem(1, 1).thenTag(2).head shouldBe TagPath.fromItem(1, 1)
+    TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3).head shouldBe TagPath.fromItem(1, 1)
+  }
+
+  "The tail of a tag path" should "be the whole part except the root element" in {
+    TagPath.fromTag(1).tail shouldBe EmptyTagPath
+    TagPath.fromItem(1, 1).tail shouldBe EmptyTagPath
+    TagPath.fromItem(1, 1).thenTag(2).tail shouldBe TagPath.fromTag(2)
+    TagPath.fromItem(1, 1).thenItem(2, 1).thenTag(3).tail shouldBe TagPath.fromItem(2, 1).thenTag(3)
+  }
+}

--- a/src/test/scala/se/nimsa/dicom/data/TagPathTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagPathTest.scala
@@ -5,28 +5,30 @@ import se.nimsa.dicom.data.TagPath.EmptyTagPath
 
 class TagPathTest extends FlatSpec with Matchers {
 
+  import TagPath.TagPathTag
+
   "The tag path depth" should "be 1 when pointing to a tag in the root dataset" in {
     val path = TagPath.fromTag(Tag.PatientID)
     path.depth shouldBe 1
   }
 
   it should "be 0 for empty tag paths" in {
-   EmptyTagPath.depth shouldBe 0
+    EmptyTagPath.depth shouldBe 0
   }
 
   it should "be 4 when pointing to a tag in three levels of sequences" in {
-    val path = TagPath.fromSequence(Tag.DerivationCodeSequence).thenSequence(Tag.DerivationCodeSequence, 3).thenSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(Tag.DerivationCodeSequence, 3).thenItem(Tag.DerivationCodeSequence, 5).thenTag(Tag.PatientID)
     path.depth shouldBe 4
   }
 
   "A tag path" should "have a legible string representation" in {
-    val path = TagPath.fromSequence(Tag.DerivationCodeSequence).thenSequence(Tag.DerivationCodeSequence, 3).thenSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
-    path.toString(lookup = false) shouldBe "(0008,9215)[*].(0008,9215)[3].(0008,9215)[*].(0010,0020)"
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 4).thenItem(Tag.DerivationCodeSequence, 3).thenItem(Tag.DerivationCodeSequence, 2).thenTag(Tag.PatientID)
+    path.toString(lookup = false) shouldBe "(0008,9215)[4].(0008,9215)[3].(0008,9215)[2].(0010,0020)"
   }
 
   it should "support string representations with keywords instead of tag numbers where possible" in {
-    val path = TagPath.fromSequence(Tag.DerivationCodeSequence).thenSequence(0x11110100, 3).thenSequence(Tag.DetectorInformationSequence).thenTag(Tag.PatientID)
-    path.toString(lookup = true) shouldBe "DerivationCodeSequence[*].(1111,0100)[3].DetectorInformationSequence[*].PatientID"
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(0x11110100, 3).thenItem(Tag.DetectorInformationSequence, 3).thenTag(Tag.PatientID)
+    path.toString(lookup = true) shouldBe "DerivationCodeSequence[1].(1111,0100)[3].DetectorInformationSequence[3].PatientID"
   }
 
   it should "be root when pointing to root dataset" in {
@@ -35,7 +37,7 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "not be root when pointing to a tag in a sequence" in {
-    val path = TagPath.fromSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientID)
     path.isRoot shouldBe false
   }
 
@@ -45,7 +47,7 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "contain four entries for a path of depth 3" in {
-    val path = TagPath.fromSequence(Tag.DerivationCodeSequence).thenSequence(Tag.DerivationCodeSequence, 3).thenSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    val path = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(Tag.DerivationCodeSequence, 3).thenItem(Tag.DerivationCodeSequence, 2).thenTag(Tag.PatientID)
     path.toList shouldBe path.previous.previous.previous :: path.previous.previous :: path.previous :: path :: Nil
   }
 
@@ -55,8 +57,8 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "return false when comparing two equivalent tag paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(1, 3).thenSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1).thenSequence(1, 3).thenSequence(1).thenTag(2)
+    val aPath = TagPath.fromItem(1, 1).thenItem(1, 3).thenItem(1, 1).thenTag(2)
+    val bPath = TagPath.fromItem(1, 1).thenItem(1, 3).thenItem(1, 1).thenTag(2)
     aPath < bPath shouldBe false
   }
 
@@ -67,34 +69,27 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "sort them by tag number for depth 1 paths" in {
-    val aPath = TagPath.fromSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1).thenTag(1)
+    val aPath = TagPath.fromItem(1, 1).thenTag(2)
+    val bPath = TagPath.fromItem(1, 1).thenTag(1)
     aPath < bPath shouldBe false
   }
 
   it should "sort by earliest difference in deep paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(1).thenTag(1)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenTag(1)
+    val aPath = TagPath.fromItem(1, 1).thenItem(1, 2).thenTag(1)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(1)
     aPath < bPath shouldBe true
   }
 
   it should "sort longer lists after shorter lists when otherwise equivalent" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3)
     aPath < bPath shouldBe false
   }
 
   it should "sort by item number in otherwise equivalent paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(1, 2).thenSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1).thenSequence(1, 3).thenSequence(1).thenTag(2)
+    val aPath = TagPath.fromItem(1, 1).thenItem(1, 2).thenItem(1, 2).thenTag(2)
+    val bPath = TagPath.fromItem(1, 1).thenItem(1, 3).thenItem(1, 2).thenTag(2)
     aPath < bPath shouldBe true
-  }
-
-  it should "should not define an ordering when comparing item indices and wildcards" in {
-    val aPath = TagPath.fromSequence(1)
-    val bPath = TagPath.fromSequence(1, 1)
-    aPath < bPath shouldBe false
-    bPath < aPath shouldBe false
   }
 
   it should "not provide a particular ordering of two empty tag paths" in {
@@ -103,44 +98,36 @@ class TagPathTest extends FlatSpec with Matchers {
 
   it should "sort empty paths as less than any other path" in {
     EmptyTagPath < TagPath.fromTag(0) shouldBe true
-    EmptyTagPath < TagPath.fromSequence(0) shouldBe true
-    EmptyTagPath < TagPath.fromSequence(0, 1) shouldBe true
+    EmptyTagPath < TagPath.fromItem(0, 1) shouldBe true
   }
 
   it should "sort non-empty tag paths after empty paths" in {
     TagPath.fromTag(0) < EmptyTagPath shouldBe false
-    TagPath.fromSequence(0) < EmptyTagPath shouldBe false
-    TagPath.fromSequence(0, 1) < EmptyTagPath shouldBe false
+    TagPath.fromItem(0, 1) < EmptyTagPath shouldBe false
 
   }
 
   "Two tag paths" should "be equal if they point to the same path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     aPath shouldBe bPath
   }
 
   it should "not be equal if item indices do not match" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2, 1).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2, 2).thenSequence(3).thenTag(4)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     aPath should not be bPath
   }
 
   it should "not be equal if they point to different tags" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(5)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(5)
     aPath should not be bPath
   }
 
   it should "not be equal if they have different depths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    aPath should not be bPath
-  }
-
-  it should "not be equal if one points to all indices of a sequence and the other points to a specific index" in {
-    val aPath = TagPath.fromSequence(1)
-    val bPath = TagPath.fromSequence(1, 1)
+    val aPath = TagPath.fromItem(1, 1).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     aPath should not be bPath
   }
 
@@ -149,8 +136,8 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   "The startsWith test" should "return true for equal paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     aPath.startsWith(bPath) shouldBe true
   }
 
@@ -169,153 +156,25 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "return false when subject path is longer than path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     aPath.startsWith(bPath) shouldBe false
   }
 
   it should "return true when paths involving item indices are equal" in {
-    val aPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
+    val aPath = TagPath.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
+    val bPath = TagPath.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
     aPath.startsWith(bPath) shouldBe true
   }
 
-  it should "return false when a path with wildcards starts with a path with item indices" in {
-    val aPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    aPath.startsWith(bPath) shouldBe false
-  }
-
-  it should "return false when a path with item indices starts with a path with wildcards" in {
-    val aPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    val bPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWith(bPath) shouldBe false
-  }
-
   it should "return true when subject path is subset of path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3)
+    val aPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3)
     aPath.startsWith(bPath) shouldBe true
-  }
-
-  "The startsWithSubPath test" should "return true for equal paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return false when subject path is longer than path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSubPath(bPath) shouldBe false
-  }
-
-  it should "return true when paths involving item indices are equal" in {
-    val aPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
-    aPath.startsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return true when a path with wildcards starts with a path with item indices" in {
-    val aPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    aPath.startsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return false when a path with item indices starts with a path with wildcards" in {
-    val aPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    val bPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSubPath(bPath) shouldBe false
-  }
-
-  it should "return true when subject path is subset of path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3)
-    aPath.startsWithSubPath(bPath) shouldBe true
-  }
-
-  "The startsWithSuperPath test" should "return true for equal paths" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSuperPath(bPath) shouldBe true
-  }
-
-  it should "return false when subject path is longer than path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSuperPath(bPath) shouldBe false
-  }
-
-  it should "return true when paths involving item indices are equal" in {
-    val aPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 4).thenSequence(2).thenSequence(3, 2).thenTag(4)
-    aPath.startsWithSuperPath(bPath) shouldBe true
-  }
-
-  it should "return false when a path with wildcards starts with a path with item indices" in {
-    val aPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    aPath.startsWithSuperPath(bPath) shouldBe false
-  }
-
-  it should "return true when a path with item indices starts with a path with wildcards" in {
-    val aPath = TagPath.fromSequence(2, 4).thenSequence(3, 66).thenTag(4)
-    val bPath = TagPath.fromSequence(2).thenSequence(3).thenTag(4)
-    aPath.startsWithSuperPath(bPath) shouldBe true
-  }
-
-  it should "return true when subject path is subset of path" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1).thenSequence(2).thenSequence(3)
-    aPath.startsWithSuperPath(bPath) shouldBe true
-  }
-
-  "The sub path test" should "return false for unequal length paths" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    aPath.hasSubPath(bPath) shouldBe false
-  }
-
-  it should "return true when subject path has items and path has wildcards" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2, 4).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    aPath.hasSubPath(bPath) shouldBe true
-  }
-
-  it should "return false when subject path has wildcards and path has items" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2).thenTag(4)
-    aPath.hasSubPath(bPath) shouldBe false
-  }
-
-  it should "return true for two empty paths" in {
-    EmptyTagPath.hasSubPath(EmptyTagPath) shouldBe true
-  }
-
-  "The super path test" should "return false for unequal length paths" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenSequence(3).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    aPath.hasSuperPath(bPath) shouldBe false
-  }
-
-  it should "return false when subject path has items and path has wildcards" in {
-    val aPath = TagPath.fromSequence(1).thenSequence(2, 4).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    aPath.hasSuperPath(bPath) shouldBe false
-  }
-
-  it should "return true when subject path has wildcards and path has items" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenTag(4)
-    val bPath = TagPath.fromSequence(1, 3).thenSequence(2).thenTag(4)
-    aPath.hasSuperPath(bPath) shouldBe true
-  }
-
-  it should "return true for two empty paths" in {
-    EmptyTagPath.hasSuperPath(EmptyTagPath) shouldBe true
   }
 
   "The endsWith test" should "return true when a longer tag ends with a shorter" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
+    val aPath = TagPath.fromItem(1, 3).thenTag(2)
     val bPath = TagPath.fromTag(2)
     aPath.endsWith(bPath) shouldBe true
   }
@@ -335,132 +194,53 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   it should "return false when a shorter tag is compared to a longer" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
+    val aPath = TagPath.fromItem(1, 3).thenTag(2)
     val bPath = TagPath.fromTag(2)
     bPath.endsWith(aPath) shouldBe false
   }
 
   it should "return false when tag numbers do not match" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
+    val aPath = TagPath.fromItem(1, 3).thenTag(2)
     val bPath = TagPath.fromTag(4)
     aPath.endsWith(bPath) shouldBe false
   }
 
   it should "work also with deep sequences" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenSequence(3, 5).thenTag(6)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 5).thenTag(6)
+    val aPath = TagPath.fromItem(1, 3).thenItem(2, 4).thenItem(3, 5).thenTag(6)
+    val bPath = TagPath.fromItem(2, 4).thenItem(3, 5).thenTag(6)
     aPath.endsWith(bPath) shouldBe true
   }
 
-  it should "return false for a subject path with wildcards when the path has item indices and vice versa" in {
-    val aPath = TagPath.fromSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1, 4).thenTag(2)
-    aPath.endsWith(bPath) shouldBe false
-    bPath.endsWith(aPath) shouldBe false
-  }
-
-  "The endsWithSubPath test" should "return true when a longer tag ends with a shorter" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(2)
-    aPath.endsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return false when a shorter tag is compared to a longer" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(2)
-    bPath.endsWithSubPath(aPath) shouldBe false
-  }
-
-  it should "return false when tag numbers do not match" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(4)
-    aPath.endsWithSubPath(bPath) shouldBe false
-  }
-
-  it should "work also with deep sequences" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenSequence(3, 5).thenTag(6)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 5).thenTag(6)
-    aPath.endsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return true for a subject path with wildcards when the path has item indices" in {
-    val aPath = TagPath.fromSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1, 4).thenTag(2)
-    aPath.endsWithSubPath(bPath) shouldBe true
-  }
-
-  it should "return false for a subject path with item indices when the path has wildcards" in {
-    val aPath = TagPath.fromSequence(1, 4).thenTag(2)
-    val bPath = TagPath.fromSequence(1).thenTag(2)
-    aPath.endsWithSubPath(bPath) shouldBe false
-  }
-
-  "The endsWithSuperPath test" should "return true when a longer tag ends with a shorter" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(2)
-    aPath.endsWithSuperPath(bPath) shouldBe true
-  }
-
-  it should "return false when a shorter tag is compared to a longer" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(2)
-    bPath.endsWithSuperPath(aPath) shouldBe false
-  }
-
-  it should "return false when tag numbers do not match" in {
-    val aPath = TagPath.fromSequence(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(4)
-    aPath.endsWithSuperPath(bPath) shouldBe false
-  }
-
-  it should "work also with deep sequences" in {
-    val aPath = TagPath.fromSequence(1, 3).thenSequence(2, 4).thenSequence(3, 5).thenTag(6)
-    val bPath = TagPath.fromSequence(2, 4).thenSequence(3, 5).thenTag(6)
-    aPath.endsWithSuperPath(bPath) shouldBe true
-  }
-
-  it should "return false for a subject path with wildcards when the path has item indices" in {
-    val aPath = TagPath.fromSequence(1).thenTag(2)
-    val bPath = TagPath.fromSequence(1, 4).thenTag(2)
-    aPath.endsWithSuperPath(bPath) shouldBe false
-  }
-
-  it should "return true for a subject path with item indices when the path has wildcards" in {
-    val aPath = TagPath.fromSequence(1, 4).thenTag(2)
-    val bPath = TagPath.fromSequence(1).thenTag(2)
-    aPath.endsWithSuperPath(bPath) shouldBe true
-  }
-
   "Parsing a tag path" should "work for well-formed depth 0 tag paths" in {
-    TagPath.parse("(0010,0010)") shouldBe TagPath.fromTag(Tag.PatientName)
+    TagPathTag.parse("(0010,0010)") shouldBe TagPath.fromTag(Tag.PatientName)
   }
 
   it should "work for deep tag paths" in {
-    TagPath.parse("(0008,9215)[*].(0008,9215)[666].(0010,0010)") shouldBe TagPath.fromSequence(Tag.DerivationCodeSequence).thenSequence(Tag.DerivationCodeSequence, 666).thenTag(Tag.PatientName)
+    TagPathTag.parse("(0008,9215)[1].(0008,9215)[666].(0010,0010)") shouldBe TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenItem(Tag.DerivationCodeSequence, 666).thenTag(Tag.PatientName)
   }
 
   it should "throw an exception for malformed strings" in {
     intercept[IllegalArgumentException] {
-      TagPath.parse("abc")
+      TagPathTag.parse("abc")
     }
   }
 
   it should "throw an exception for empty strings" in {
     intercept[IllegalArgumentException] {
-      TagPath.parse("")
+      TagPathTag.parse("")
     }
   }
 
   it should "accept both tag numbers and keywords" in {
-    val ref = TagPath.fromSequence(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName)
-    TagPath.parse("(0008,9215)[1].(0010,0010)") shouldBe ref
-    TagPath.parse("DerivationCodeSequence[1].(0010,0010)") shouldBe ref
-    TagPath.parse("(0008,9215)[1].PatientName") shouldBe ref
-    TagPath.parse("DerivationCodeSequence[1].PatientName") shouldBe ref
+    val ref = TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName)
+    TagPathTag.parse("(0008,9215)[1].(0010,0010)") shouldBe ref
+    TagPathTag.parse("DerivationCodeSequence[1].(0010,0010)") shouldBe ref
+    TagPathTag.parse("(0008,9215)[1].PatientName") shouldBe ref
+    TagPathTag.parse("DerivationCodeSequence[1].PatientName") shouldBe ref
   }
 
   "The contains test" should "return for any tag number on the tag path" in {
-    val path = TagPath.fromSequence(1, 1).thenSequence(2).thenTag(3)
+    val path = TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3)
     path.contains(1) shouldBe true
     path.contains(2) shouldBe true
     path.contains(3) shouldBe true
@@ -468,22 +248,22 @@ class TagPathTest extends FlatSpec with Matchers {
   }
 
   "The take operation" should "preserve elements from the left" in {
-    val path = TagPath.fromSequence(1).thenSequence(2,1).thenSequence(3).thenTag(4)
+    val path = TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3).thenTag(4)
     path.take(-100) shouldBe EmptyTagPath
     path.take(0) shouldBe EmptyTagPath
-    path.take(1) shouldBe TagPath.fromSequence(1)
-    path.take(2) shouldBe TagPath.fromSequence(1).thenSequence(2,1)
-    path.take(3) shouldBe TagPath.fromSequence(1).thenSequence(2,1).thenSequence(3)
+    path.take(1) shouldBe TagPath.fromItem(1, 1)
+    path.take(2) shouldBe TagPath.fromItem(1, 1).thenItem(2, 1)
+    path.take(3) shouldBe TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3)
     path.take(4) shouldBe path
     path.take(100) shouldBe path
   }
 
   "The drop operation" should "remove elements from the left" in {
-    val path = TagPath.fromSequence(1).thenSequence(2,1).thenSequence(3).thenTag(4)
+    val path = TagPath.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3).thenTag(4)
     path.drop(-100) shouldBe path
     path.drop(0) shouldBe path
-    path.drop(1) shouldBe TagPath.fromSequence(2,1).thenSequence(3).thenTag(4)
-    path.drop(2) shouldBe TagPath.fromSequence(3).thenTag(4)
+    path.drop(1) shouldBe TagPath.fromItem(2, 1).thenItem(3, 3).thenTag(4)
+    path.drop(2) shouldBe TagPath.fromItem(3, 3).thenTag(4)
     path.drop(3) shouldBe TagPath.fromTag(4)
     path.drop(4) shouldBe EmptyTagPath
     path.drop(100) shouldBe EmptyTagPath
@@ -491,21 +271,15 @@ class TagPathTest extends FlatSpec with Matchers {
 
   "The head of a tag path" should "be the root element of the path" in {
     TagPath.fromTag(1).head shouldBe TagPath.fromTag(1)
-    TagPath.fromSequence(1).head shouldBe TagPath.fromSequence(1)
-    TagPath.fromSequence(1, 1).head shouldBe TagPath.fromSequence(1, 1)
-    TagPath.fromSequence(1).thenTag(2).head shouldBe TagPath.fromSequence(1)
-    TagPath.fromSequence(1, 1).thenTag(2).head shouldBe TagPath.fromSequence(1, 1)
-    TagPath.fromSequence(1, 1).thenSequence(2).thenTag(3).head shouldBe TagPath.fromSequence(1, 1)
+    TagPath.fromItem(1, 1).head shouldBe TagPath.fromItem(1, 1)
+    TagPath.fromItem(1, 1).thenTag(2).head shouldBe TagPath.fromItem(1, 1)
+    TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3).head shouldBe TagPath.fromItem(1, 1)
   }
 
   "The tail of a tag path" should "be the whole part except the root element" in {
     TagPath.fromTag(1).tail shouldBe EmptyTagPath
-    TagPath.fromSequence(1).tail shouldBe EmptyTagPath
-    TagPath.fromSequence(1, 1).tail shouldBe EmptyTagPath
-    TagPath.fromSequence(1).thenTag(2).tail shouldBe TagPath.fromTag(2)
-    TagPath.fromSequence(1, 1).thenTag(2).tail shouldBe TagPath.fromTag(2)
-    TagPath.fromSequence(1, 1).thenSequence(2).thenTag(3).tail shouldBe TagPath.fromSequence(2).thenTag(3)
-    TagPath.fromSequence(1, 1).thenSequence(2, 1).thenTag(3).tail shouldBe TagPath.fromSequence(2, 1).thenTag(3)
-    TagPath.fromSequence(1).thenSequence(2).thenSequence(3).thenTag(4).tail shouldBe TagPath.fromSequence(2).thenSequence(3).thenTag(4)
+    TagPath.fromItem(1, 1).tail shouldBe EmptyTagPath
+    TagPath.fromItem(1, 1).thenTag(2).tail shouldBe TagPath.fromTag(2)
+    TagPath.fromItem(1, 1).thenItem(2, 1).thenTag(3).tail shouldBe TagPath.fromItem(2, 1).thenTag(3)
   }
 }

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -60,6 +60,46 @@ class TagTreeTest extends FlatSpec with Matchers {
     EmptyTagTree == EmptyTagTree shouldBe true
   }
 
+  it should "support equals documentation examples" in {
+    TagTree.fromTag(0x00100010) shouldEqual TagTree.fromTag(0x00100010)
+    TagTree.fromTag(0x00100010) should not equal TagTree.fromTag(0x00100020)
+    TagTree.fromTag(0x00100010) should not equal TagTree.fromItem(0x00089215, 1).thenTag(0x00100010)
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010) should not equal TagTree.fromItem(0x00089215, 1).thenTag(0x00100010)
+    TagTree.fromItem(0x00089215, 3).thenTag(0x00100010) shouldEqual TagTree.fromItem(0x00089215, 3).thenTag(0x00100010)
+  }
+
+  "The isPath test" should "support documentation examples" in {
+    TagTree.fromItem(0x00089215, 3).thenTag(0x00100010).isPath shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).isPath shouldBe false
+    EmptyTagTree.isPath shouldBe true
+  }
+
+  "The hasBranch test" should "return true for a path extending from root to leaf" in {
+    TagTree.fromAnyItem(1).thenAnyItem(2).thenItem(3, 3).thenTag(4).hasBranch(
+      TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)) shouldBe true
+  }
+
+  it should "return false for path not beginning at root" in {
+    TagTree.fromItem(1, 1).thenTag(2).hasBranch(TagPath.fromTag(2)) shouldBe false
+  }
+
+  it should "return false for path not ending at leaf" in {
+    TagTree.fromItem(1, 1).thenTag(2).hasBranch(TagPath.fromItem(1, 1)) shouldBe false
+  }
+
+  it should "work with sequence and item end nodes" in {
+    TagTree.fromAnyItem(1).hasBranch(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).hasBranch(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).hasBranch(TagPath.fromSequence(1)) shouldBe true
+    TagTree.fromAnyItem(1).hasBranch(TagPath.fromSequenceEnd(1)) shouldBe true
+  }
+
+  it should "support documentation examples" in {
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasBranch(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasBranch(TagPath.fromItem(0x00089215, 1)) shouldBe false
+    EmptyTagTree.hasBranch(EmptyTagPath) shouldBe true
+  }
+
   "The hasTrunk test" should "return true for equally shaped tree and path" in {
     val tree = TagTree.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
     val path = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
@@ -90,6 +130,46 @@ class TagTreeTest extends FlatSpec with Matchers {
     val tree = TagTree.fromAnyItem(2).thenAnyItem(3).thenTag(4)
     val path = TagPath.fromItem(2, 4).thenItem(3, 66).thenTag(4)
     tree.hasTrunk(path) shouldBe true
+  }
+
+  it should "work with sequence and item end nodes" in {
+    TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).thenTag(2).hasTrunk(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromSequence(1)) shouldBe true
+    TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromSequenceEnd(1)) shouldBe true
+  }
+
+  it should "support documentation examples" in {
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTrunk(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTrunk(TagPath.fromItem(0x00089215, 1)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTrunk(TagPath.fromTag(0x00100010)) shouldBe false
+  }
+
+  "The isTrunkOf test" should "return true for a tag path extending out of a tag tree" in {
+    TagTree.fromAnyItem(1).thenItem(2, 2).isTrunkOf(TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3)) shouldBe true
+  }
+
+  it should "return true for tree and path of equals length" in {
+    TagTree.fromAnyItem(1).thenItem(2, 2).isTrunkOf(TagPath.fromItem(1, 1).thenItem(2, 2)) shouldBe true
+  }
+
+  it should "return false for a trunk of a tree" in {
+    TagTree.fromAnyItem(1).thenItem(2, 2).isTrunkOf(TagPath.fromItem(1, 1)) shouldBe false
+  }
+
+  it should "work with sequence and item end nodes" in {
+    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromSequence(1)) shouldBe true
+    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromSequenceEnd(1)) shouldBe true
+  }
+
+  it should "support documentation examples" in {
+    TagTree.fromItem(0x00089215, 1).thenTag(0x00100010).isTrunkOf(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).isTrunkOf(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).isTrunkOf(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromItem(0x00089215, 3).isTrunkOf(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe false
+    TagTree.fromTag(0x00100010).isTrunkOf(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe false
   }
 
   "The hasTwig test" should "return true when a longer tree ends with a shorter path" in {
@@ -130,6 +210,19 @@ class TagTreeTest extends FlatSpec with Matchers {
     tree.hasTwig(path) shouldBe true
   }
 
+  it should "work with sequence and item end nodes" in {
+    TagTree.fromAnyItem(1).hasTwig(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).hasTwig(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).hasTwig(TagPath.fromSequence(1)) shouldBe true
+    TagTree.fromAnyItem(1).hasTwig(TagPath.fromSequenceEnd(1)) shouldBe true
+  }
+
+  it should "support documentation examples" in {
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTwig(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTwig(TagPath.fromTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTwig(TagPath.fromItem(0x00089215, 1)) shouldBe false
+  }
+
   "Parsing a tag tree" should "work for well-formed depth 0 tag trees" in {
     TagTree.parse("(0010,0010)") shouldBe TagTree.fromTag(Tag.PatientName)
   }
@@ -159,13 +252,14 @@ class TagTreeTest extends FlatSpec with Matchers {
   }
 
   "The drop operation" should "remove elements from the left" in {
-    val tree = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
-    tree.drop(-100) shouldBe tree
-    tree.drop(0) shouldBe tree
-    tree.drop(1) shouldBe TagTree.fromItem(2, 1).thenAnyItem(3).thenTag(4)
-    tree.drop(2) shouldBe TagTree.fromAnyItem(3).thenTag(4)
-    tree.drop(3) shouldBe TagTree.fromTag(4)
-    tree.drop(4) shouldBe EmptyTagTree
-    tree.drop(100) shouldBe EmptyTagTree
+    val path = TagTree.fromItem(1, 1).thenItem(2, 1).thenItem(3, 3).thenTag(4)
+    path.drop(-100) shouldBe path
+    path.drop(0) shouldBe path
+    path.drop(1) shouldBe TagTree.fromItem(2, 1).thenItem(3, 3).thenTag(4)
+    path.drop(2) shouldBe TagTree.fromItem(3, 3).thenTag(4)
+    path.drop(3) shouldBe TagTree.fromTag(4)
+    path.drop(4) shouldBe EmptyTagTree
+    path.drop(100) shouldBe EmptyTagTree
   }
+
 }

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -6,147 +6,135 @@ import se.nimsa.dicom.data.TagTree.EmptyTagTree
 
 class TagTreeTest extends FlatSpec with Matchers {
 
-  "A tag query" should "have a legible string representation" in {
-    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(Tag.DerivationCodeSequence, 3).thenAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
-    path.toString(lookup = false) shouldBe "(0008,9215)[*].(0008,9215)[3].(0008,9215)[*].(0010,0020)"
+  "A tag tree" should "have a legible string representation" in {
+    val tree = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(Tag.DerivationCodeSequence, 3).thenAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    tree.toString(lookup = false) shouldBe "(0008,9215)[*].(0008,9215)[3].(0008,9215)[*].(0010,0020)"
   }
 
   it should "support string representations with keywords instead of tag numbers where possible" in {
-    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(0x11110100, 3).thenAnyItem(Tag.DetectorInformationSequence).thenTag(Tag.PatientID)
-    path.toString(lookup = true) shouldBe "DerivationCodeSequence[*].(1111,0100)[3].DetectorInformationSequence[*].PatientID"
+    val tree = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(0x11110100, 3).thenAnyItem(Tag.DetectorInformationSequence).thenTag(Tag.PatientID)
+    tree.toString(lookup = true) shouldBe "DerivationCodeSequence[*].(1111,0100)[3].DetectorInformationSequence[*].PatientID"
   }
 
   it should "be root when pointing to root dataset" in {
-    val path = TagTree.fromTag(Tag.PatientID)
-    path.isRoot shouldBe true
+    val tree = TagTree.fromTag(Tag.PatientID)
+    tree.isRoot shouldBe true
   }
 
   it should "not be root when pointing to a tag in a sequence" in {
-    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
-    path.isRoot shouldBe false
+    val tree = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    tree.isRoot shouldBe false
   }
 
-  "Two tag queries" should "be equal if they point to the same path" in {
-    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
-    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
-    aPath shouldBe bPath
+  "Two tag trees" should "be equal if they point to the same tree" in {
+    val aTree = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bTree = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    aTree shouldBe bTree
   }
 
   it should "not be equal if item indices do not match" in {
-    val aPath = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
-    val bPath = TagTree.fromAnyItem(1).thenItem(2, 2).thenAnyItem(3).thenTag(4)
-    aPath should not be bPath
+    val aTree = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
+    val bTree = TagTree.fromAnyItem(1).thenItem(2, 2).thenAnyItem(3).thenTag(4)
+    aTree should not be bTree
   }
 
   it should "not be equal if they point to different tags" in {
-    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
-    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(5)
-    aPath should not be bPath
+    val aTree = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bTree = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(5)
+    aTree should not be bTree
   }
 
   it should "not be equal if they have different depths" in {
-    val aPath = TagTree.fromAnyItem(1).thenAnyItem(3).thenTag(4)
-    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
-    aPath should not be bPath
+    val aTree = TagTree.fromAnyItem(1).thenAnyItem(3).thenTag(4)
+    val bTree = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    aTree should not be bTree
   }
 
   it should "not be equal if one points to all indices of a sequence and the other points to a specific index" in {
-    val aPath = TagTree.fromAnyItem(1)
-    val bPath = TagTree.fromItem(1, 1)
-    aPath should not be bPath
+    val aTree = TagTree.fromAnyItem(1)
+    val bTree = TagTree.fromItem(1, 1)
+    aTree should not be bTree
   }
 
   it should "be equal if both are empty" in {
     EmptyTagTree == EmptyTagTree shouldBe true
   }
 
-  "The contains test" should "return true for equal paths" in {
-    val aPath = TagTree.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
-    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
-    aPath.hasTrunk(bPath) shouldBe true
+  "The hasTrunk test" should "return true for equally shaped tree and path" in {
+    val tree = TagTree.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val path = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    tree.hasTrunk(path) shouldBe true
   }
 
-  it should "return true for two empty paths" in {
+  it should "return true for two empty structures" in {
     EmptyTagTree.hasTrunk(EmptyTagPath) shouldBe true
   }
 
-  it should "return true when any path starts with empty path" in {
-    val aPath = TagTree.fromTag(1)
-    aPath.hasTrunk(EmptyTagPath) shouldBe true
+  it should "return true when subject path is empty" in {
+    val aTree = TagTree.fromTag(1)
+    aTree.hasTrunk(EmptyTagPath) shouldBe true
   }
 
-  it should "return false when empty path starts with non-empty path" in {
-    val aPath = TagPath.fromTag(1)
-    EmptyTagTree.hasTrunk(aPath) shouldBe false
+  it should "return false when empty tree starts with non-empty path" in {
+    val path = TagPath.fromTag(1)
+    EmptyTagTree.hasTrunk(path) shouldBe false
   }
 
-  it should "return false when subject path is longer than path" in {
-    val aPath = TagTree.fromItem(1, 1).thenItem(2, 2).thenTag(4)
-    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
-    aPath.hasTrunk(bPath) shouldBe false
+  it should "return false when subject path is longer than tree" in {
+    val tree = TagTree.fromItem(1, 1).thenItem(2, 2).thenTag(4)
+    val path = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    tree.hasTrunk(path) shouldBe false
   }
 
-  it should "return true when paths involving item indices are equal" in {
-    val aPath = TagTree.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
-    val bPath = TagPath.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
-    aPath.hasTrunk(bPath) shouldBe true
+  it should "return true when a tree with wildcards is compared to a path with item indices" in {
+    val tree = TagTree.fromAnyItem(2).thenAnyItem(3).thenTag(4)
+    val path = TagPath.fromItem(2, 4).thenItem(3, 66).thenTag(4)
+    tree.hasTrunk(path) shouldBe true
   }
 
-  it should "return false when a path with wildcards starts with a path with item indices" in {
-    val aPath = TagTree.fromAnyItem(2).thenAnyItem(3).thenTag(4)
-    val bPath = TagPath.fromItem(2, 4).thenItem(3, 66).thenTag(4)
-    aPath.hasTrunk(bPath) shouldBe false
+  "The hasTwig test" should "return true when a longer tree ends with a shorter path" in {
+    val tree = TagTree.fromItem(1, 3).thenTag(2)
+    val path = TagPath.fromTag(2)
+    tree.hasTwig(path) shouldBe true
   }
 
-  it should "return true when subject path is subset of path" in {
-    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
-    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 1)
-    aPath.hasTrunk(bPath) shouldBe true
-  }
-
-  "The endsWith test" should "return true when a longer tag ends with a shorter" in {
-    val aPath = TagTree.fromItem(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(2)
-    aPath.hasTwig(bPath) shouldBe true
-  }
-
-  it should "return true for two empty paths" in {
+  it should "return true for empty tree and path" in {
     EmptyTagTree.hasTwig(EmptyTagPath) shouldBe true
   }
 
-  it should "return false when checking if non-empty path ends with empty path" in {
-    val aPath = TagTree.fromTag(1)
-    aPath.hasTwig(EmptyTagPath) shouldBe false
+  it should "return false when checking if non-empty tree ends with empty path" in {
+    val aTree = TagTree.fromTag(1)
+    aTree.hasTwig(EmptyTagPath) shouldBe false
   }
 
-  it should "return false when empty path starts with non-empty path" in {
-    val aPath = TagPath.fromTag(1)
-    EmptyTagTree.hasTwig(aPath) shouldBe false
+  it should "return false when empty tree starts with non-empty path" in {
+    val path = TagPath.fromTag(1)
+    EmptyTagTree.hasTwig(path) shouldBe false
   }
 
-  it should "return false when a shorter tag is compared to a longer" in {
-    val aPath = TagPath.fromItem(1, 3).thenTag(2)
-    val bPath = TagTree.fromTag(2)
-    bPath.hasTwig(aPath) shouldBe false
+  it should "return false when a shorter tree is compared to a longer path" in {
+    val path = TagPath.fromItem(1, 3).thenTag(2)
+    val tree = TagTree.fromTag(2)
+    tree.hasTwig(path) shouldBe false
   }
 
   it should "return false when tag numbers do not match" in {
-    val aPath = TagTree.fromItem(1, 3).thenTag(2)
-    val bPath = TagPath.fromTag(4)
-    aPath.hasTwig(bPath) shouldBe false
+    val tree = TagTree.fromItem(1, 3).thenTag(2)
+    val path = TagPath.fromTag(4)
+    tree.hasTwig(path) shouldBe false
   }
 
-  it should "work also with deep sequences" in {
-    val aPath = TagTree.fromItem(1, 3).thenItem(2, 4).thenItem(3, 5).thenTag(6)
-    val bPath = TagPath.fromItem(2, 4).thenItem(3, 5).thenTag(6)
-    aPath.hasTwig(bPath) shouldBe true
+  it should "work also with deep structures" in {
+    val tree = TagTree.fromItem(1, 3).thenItem(2, 4).thenItem(3, 5).thenTag(6)
+    val path = TagPath.fromItem(2, 4).thenItem(3, 5).thenTag(6)
+    tree.hasTwig(path) shouldBe true
   }
 
-  "Parsing a tag query" should "work for well-formed depth 0 tag queries" in {
+  "Parsing a tag tree" should "work for well-formed depth 0 tag trees" in {
     TagTree.parse("(0010,0010)") shouldBe TagTree.fromTag(Tag.PatientName)
   }
 
-  it should "work for deep tag paths" in {
+  it should "work for deep tag trees" in {
     TagTree.parse("(0008,9215)[*].(0008,9215)[666].(0010,0010)") shouldBe TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(Tag.DerivationCodeSequence, 666).thenTag(Tag.PatientName)
   }
 
@@ -171,13 +159,13 @@ class TagTreeTest extends FlatSpec with Matchers {
   }
 
   "The drop operation" should "remove elements from the left" in {
-    val path = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
-    path.drop(-100) shouldBe path
-    path.drop(0) shouldBe path
-    path.drop(1) shouldBe TagTree.fromItem(2, 1).thenAnyItem(3).thenTag(4)
-    path.drop(2) shouldBe TagTree.fromAnyItem(3).thenTag(4)
-    path.drop(3) shouldBe TagTree.fromTag(4)
-    path.drop(4) shouldBe EmptyTagTree
-    path.drop(100) shouldBe EmptyTagTree
+    val tree = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
+    tree.drop(-100) shouldBe tree
+    tree.drop(0) shouldBe tree
+    tree.drop(1) shouldBe TagTree.fromItem(2, 1).thenAnyItem(3).thenTag(4)
+    tree.drop(2) shouldBe TagTree.fromAnyItem(3).thenTag(4)
+    tree.drop(3) shouldBe TagTree.fromTag(4)
+    tree.drop(4) shouldBe EmptyTagTree
+    tree.drop(100) shouldBe EmptyTagTree
   }
 }

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -132,11 +132,19 @@ class TagTreeTest extends FlatSpec with Matchers {
     tree.hasTrunk(path) shouldBe true
   }
 
-  it should "work with sequence and item end nodes" in {
+  it should "work with sequence start and end nodes" in {
+    val tree1 = TagTree.fromItem(1, 1).thenTag(2)
+    tree1.hasTrunk(TagPath.fromSequence(1)) shouldBe true
+    tree1.hasTrunk(TagPath.fromSequenceEnd(1)) shouldBe true
+
+    val tree2 = TagTree.fromAnyItem(1).thenTag(2)
+    tree2.hasTrunk(TagPath.fromSequence(1)) shouldBe true
+    tree2.hasTrunk(TagPath.fromSequenceEnd(1)) shouldBe true
+  }
+
+  it should "work with item start and end nodes" in {
     TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromItemEnd(1, 1)) shouldBe true
     TagTree.fromItem(1, 1).thenTag(2).hasTrunk(TagPath.fromItemEnd(1, 1)) shouldBe true
-    TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromSequence(1)) shouldBe true
-    TagTree.fromAnyItem(1).thenTag(2).hasTrunk(TagPath.fromSequenceEnd(1)) shouldBe true
   }
 
   it should "support documentation examples" in {
@@ -157,11 +165,18 @@ class TagTreeTest extends FlatSpec with Matchers {
     TagTree.fromAnyItem(1).thenItem(2, 2).isTrunkOf(TagPath.fromItem(1, 1)) shouldBe false
   }
 
-  it should "work with sequence and item end nodes" in {
-    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
-    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
+  it should "work with sequence start and end nodes" in {
     TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromSequence(1)) shouldBe true
     TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromSequenceEnd(1)) shouldBe true
+    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromSequence(1)) shouldBe false
+    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromSequenceEnd(1)) shouldBe false
+  }
+
+  it should "work with item start and end nodes" in {
+    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromItem(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromItem(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).isTrunkOf(TagPath.fromItemEnd(1, 1)) shouldBe true
   }
 
   it should "support documentation examples" in {
@@ -232,13 +247,13 @@ class TagTreeTest extends FlatSpec with Matchers {
   }
 
   it should "handle deep paths" in {
-    TagTree.fromPath(TagPath.fromItem(1,1).thenItem(2,2).thenTag(3)) shouldBe TagTree.fromItem(1,1).thenItem(2,2).thenTag(3)
+    TagTree.fromPath(TagPath.fromItem(1, 1).thenItem(2, 2).thenTag(3)) shouldBe TagTree.fromItem(1, 1).thenItem(2, 2).thenTag(3)
   }
 
   it should "handle sequence and item start and end nodes" in {
     TagTree.fromPath(TagPath.fromSequence(1)) shouldBe TagTree.fromAnyItem(1)
     TagTree.fromPath(TagPath.fromSequenceEnd(1)) shouldBe TagTree.fromAnyItem(1)
-    TagTree.fromPath(TagPath.fromItemEnd(1,1)) shouldBe TagTree.fromItem(1,1)
+    TagTree.fromPath(TagPath.fromItemEnd(1, 1)) shouldBe TagTree.fromItem(1, 1)
   }
 
   "Parsing a tag tree" should "work for well-formed depth 0 tag trees" in {

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -74,30 +74,30 @@ class TagTreeTest extends FlatSpec with Matchers {
     EmptyTagTree.isPath shouldBe true
   }
 
-  "The hasBranch test" should "return true for a path extending from root to leaf" in {
-    TagTree.fromAnyItem(1).thenAnyItem(2).thenItem(3, 3).thenTag(4).hasBranch(
+  "The hasPath test" should "return true for a path extending from root to leaf" in {
+    TagTree.fromAnyItem(1).thenAnyItem(2).thenItem(3, 3).thenTag(4).hasPath(
       TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)) shouldBe true
   }
 
   it should "return false for path not beginning at root" in {
-    TagTree.fromItem(1, 1).thenTag(2).hasBranch(TagPath.fromTag(2)) shouldBe false
+    TagTree.fromItem(1, 1).thenTag(2).hasPath(TagPath.fromTag(2)) shouldBe false
   }
 
   it should "return false for path not ending at leaf" in {
-    TagTree.fromItem(1, 1).thenTag(2).hasBranch(TagPath.fromItem(1, 1)) shouldBe false
+    TagTree.fromItem(1, 1).thenTag(2).hasPath(TagPath.fromItem(1, 1)) shouldBe false
   }
 
   it should "work with sequence and item end nodes" in {
-    TagTree.fromAnyItem(1).hasBranch(TagPath.fromItemEnd(1, 1)) shouldBe true
-    TagTree.fromItem(1, 1).hasBranch(TagPath.fromItemEnd(1, 1)) shouldBe true
-    TagTree.fromAnyItem(1).hasBranch(TagPath.fromSequence(1)) shouldBe true
-    TagTree.fromAnyItem(1).hasBranch(TagPath.fromSequenceEnd(1)) shouldBe true
+    TagTree.fromAnyItem(1).hasPath(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromItem(1, 1).hasPath(TagPath.fromItemEnd(1, 1)) shouldBe true
+    TagTree.fromAnyItem(1).hasPath(TagPath.fromSequence(1)) shouldBe true
+    TagTree.fromAnyItem(1).hasPath(TagPath.fromSequenceEnd(1)) shouldBe true
   }
 
   it should "support documentation examples" in {
-    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasBranch(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
-    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasBranch(TagPath.fromItem(0x00089215, 1)) shouldBe false
-    EmptyTagTree.hasBranch(EmptyTagPath) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasPath(TagPath.fromItem(0x00089215, 1).thenTag(0x00100010)) shouldBe true
+    TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasPath(TagPath.fromItem(0x00089215, 1)) shouldBe false
+    EmptyTagTree.hasPath(EmptyTagPath) shouldBe true
   }
 
   "The hasTrunk test" should "return true for equally shaped tree and path" in {

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -1,0 +1,183 @@
+package se.nimsa.dicom.data
+
+import org.scalatest.{FlatSpec, Matchers}
+import se.nimsa.dicom.data.TagPath.EmptyTagPath
+import se.nimsa.dicom.data.TagTree.EmptyTagTree
+
+class TagTreeTest extends FlatSpec with Matchers {
+
+  "A tag query" should "have a legible string representation" in {
+    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(Tag.DerivationCodeSequence, 3).thenAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    path.toString(lookup = false) shouldBe "(0008,9215)[*].(0008,9215)[3].(0008,9215)[*].(0010,0020)"
+  }
+
+  it should "support string representations with keywords instead of tag numbers where possible" in {
+    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(0x11110100, 3).thenAnyItem(Tag.DetectorInformationSequence).thenTag(Tag.PatientID)
+    path.toString(lookup = true) shouldBe "DerivationCodeSequence[*].(1111,0100)[3].DetectorInformationSequence[*].PatientID"
+  }
+
+  it should "be root when pointing to root dataset" in {
+    val path = TagTree.fromTag(Tag.PatientID)
+    path.isRoot shouldBe true
+  }
+
+  it should "not be root when pointing to a tag in a sequence" in {
+    val path = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientID)
+    path.isRoot shouldBe false
+  }
+
+  "Two tag queries" should "be equal if they point to the same path" in {
+    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    aPath shouldBe bPath
+  }
+
+  it should "not be equal if item indices do not match" in {
+    val aPath = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
+    val bPath = TagTree.fromAnyItem(1).thenItem(2, 2).thenAnyItem(3).thenTag(4)
+    aPath should not be bPath
+  }
+
+  it should "not be equal if they point to different tags" in {
+    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(5)
+    aPath should not be bPath
+  }
+
+  it should "not be equal if they have different depths" in {
+    val aPath = TagTree.fromAnyItem(1).thenAnyItem(3).thenTag(4)
+    val bPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    aPath should not be bPath
+  }
+
+  it should "not be equal if one points to all indices of a sequence and the other points to a specific index" in {
+    val aPath = TagTree.fromAnyItem(1)
+    val bPath = TagTree.fromItem(1, 1)
+    aPath should not be bPath
+  }
+
+  it should "be equal if both are empty" in {
+    EmptyTagTree == EmptyTagTree shouldBe true
+  }
+
+  "The contains test" should "return true for equal paths" in {
+    val aPath = TagTree.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    aPath.hasTrunk(bPath) shouldBe true
+  }
+
+  it should "return true for two empty paths" in {
+    EmptyTagTree.hasTrunk(EmptyTagPath) shouldBe true
+  }
+
+  it should "return true when any path starts with empty path" in {
+    val aPath = TagTree.fromTag(1)
+    aPath.hasTrunk(EmptyTagPath) shouldBe true
+  }
+
+  it should "return false when empty path starts with non-empty path" in {
+    val aPath = TagPath.fromTag(1)
+    EmptyTagTree.hasTrunk(aPath) shouldBe false
+  }
+
+  it should "return false when subject path is longer than path" in {
+    val aPath = TagTree.fromItem(1, 1).thenItem(2, 2).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 3).thenTag(4)
+    aPath.hasTrunk(bPath) shouldBe false
+  }
+
+  it should "return true when paths involving item indices are equal" in {
+    val aPath = TagTree.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
+    val bPath = TagPath.fromItem(1, 4).thenItem(2, 2).thenItem(3, 2).thenTag(4)
+    aPath.hasTrunk(bPath) shouldBe true
+  }
+
+  it should "return false when a path with wildcards starts with a path with item indices" in {
+    val aPath = TagTree.fromAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bPath = TagPath.fromItem(2, 4).thenItem(3, 66).thenTag(4)
+    aPath.hasTrunk(bPath) shouldBe false
+  }
+
+  it should "return true when subject path is subset of path" in {
+    val aPath = TagTree.fromAnyItem(1).thenAnyItem(2).thenAnyItem(3).thenTag(4)
+    val bPath = TagPath.fromItem(1, 1).thenItem(2, 2).thenItem(3, 1)
+    aPath.hasTrunk(bPath) shouldBe true
+  }
+
+  "The endsWith test" should "return true when a longer tag ends with a shorter" in {
+    val aPath = TagTree.fromItem(1, 3).thenTag(2)
+    val bPath = TagPath.fromTag(2)
+    aPath.hasTwig(bPath) shouldBe true
+  }
+
+  it should "return true for two empty paths" in {
+    EmptyTagTree.hasTwig(EmptyTagPath) shouldBe true
+  }
+
+  it should "return false when checking if non-empty path ends with empty path" in {
+    val aPath = TagTree.fromTag(1)
+    aPath.hasTwig(EmptyTagPath) shouldBe false
+  }
+
+  it should "return false when empty path starts with non-empty path" in {
+    val aPath = TagPath.fromTag(1)
+    EmptyTagTree.hasTwig(aPath) shouldBe false
+  }
+
+  it should "return false when a shorter tag is compared to a longer" in {
+    val aPath = TagPath.fromItem(1, 3).thenTag(2)
+    val bPath = TagTree.fromTag(2)
+    bPath.hasTwig(aPath) shouldBe false
+  }
+
+  it should "return false when tag numbers do not match" in {
+    val aPath = TagTree.fromItem(1, 3).thenTag(2)
+    val bPath = TagPath.fromTag(4)
+    aPath.hasTwig(bPath) shouldBe false
+  }
+
+  it should "work also with deep sequences" in {
+    val aPath = TagTree.fromItem(1, 3).thenItem(2, 4).thenItem(3, 5).thenTag(6)
+    val bPath = TagPath.fromItem(2, 4).thenItem(3, 5).thenTag(6)
+    aPath.hasTwig(bPath) shouldBe true
+  }
+
+  "Parsing a tag query" should "work for well-formed depth 0 tag queries" in {
+    TagTree.parse("(0010,0010)") shouldBe TagTree.fromTag(Tag.PatientName)
+  }
+
+  it should "work for deep tag paths" in {
+    TagTree.parse("(0008,9215)[*].(0008,9215)[666].(0010,0010)") shouldBe TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenItem(Tag.DerivationCodeSequence, 666).thenTag(Tag.PatientName)
+  }
+
+  it should "throw an exception for malformed strings" in {
+    intercept[IllegalArgumentException] {
+      TagTree.parse("abc")
+    }
+  }
+
+  it should "throw an exception for empty strings" in {
+    intercept[IllegalArgumentException] {
+      TagTree.parse("")
+    }
+  }
+
+  it should "accept both tag numbers and keywords" in {
+    val ref = TagTree.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName)
+    TagTree.parse("(0008,9215)[1].(0010,0010)") shouldBe ref
+    TagTree.parse("DerivationCodeSequence[1].(0010,0010)") shouldBe ref
+    TagTree.parse("(0008,9215)[1].PatientName") shouldBe ref
+    TagTree.parse("DerivationCodeSequence[1].PatientName") shouldBe ref
+  }
+
+  "The drop operation" should "remove elements from the left" in {
+    val path = TagTree.fromAnyItem(1).thenItem(2, 1).thenAnyItem(3).thenTag(4)
+    path.drop(-100) shouldBe path
+    path.drop(0) shouldBe path
+    path.drop(1) shouldBe TagTree.fromItem(2, 1).thenAnyItem(3).thenTag(4)
+    path.drop(2) shouldBe TagTree.fromAnyItem(3).thenTag(4)
+    path.drop(3) shouldBe TagTree.fromTag(4)
+    path.drop(4) shouldBe EmptyTagTree
+    path.drop(100) shouldBe EmptyTagTree
+  }
+}

--- a/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
+++ b/src/test/scala/se/nimsa/dicom/data/TagTreeTest.scala
@@ -223,6 +223,24 @@ class TagTreeTest extends FlatSpec with Matchers {
     TagTree.fromAnyItem(0x00089215).thenTag(0x00100010).hasTwig(TagPath.fromItem(0x00089215, 1)) shouldBe false
   }
 
+  "Creating a tag path from a tag tree" should "handle empty tag paths" in {
+    TagTree.fromPath(EmptyTagPath) shouldBe EmptyTagTree
+  }
+
+  it should "handle simple paths" in {
+    TagTree.fromPath(TagPath.fromTag(1)) shouldBe TagTree.fromTag(1)
+  }
+
+  it should "handle deep paths" in {
+    TagTree.fromPath(TagPath.fromItem(1,1).thenItem(2,2).thenTag(3)) shouldBe TagTree.fromItem(1,1).thenItem(2,2).thenTag(3)
+  }
+
+  it should "handle sequence and item start and end nodes" in {
+    TagTree.fromPath(TagPath.fromSequence(1)) shouldBe TagTree.fromAnyItem(1)
+    TagTree.fromPath(TagPath.fromSequenceEnd(1)) shouldBe TagTree.fromAnyItem(1)
+    TagTree.fromPath(TagPath.fromItemEnd(1,1)) shouldBe TagTree.fromItem(1,1)
+  }
+
   "Parsing a tag tree" should "work for well-formed depth 0 tag trees" in {
     TagTree.parse("(0010,0010)") shouldBe TagTree.fromTag(Tag.PatientName)
   }

--- a/src/test/scala/se/nimsa/dicom/streams/DicomFlowTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/DicomFlowTest.scala
@@ -370,19 +370,19 @@ class DicomFlowTest extends TestKit(ActorSystem("DicomFlowSpec")) with FlatSpecL
       TagPath.fromTag(Tag.StudyDate), // Patient name header
       TagPath.fromTag(Tag.StudyDate), // Patient name value
       TagPath.fromSequence(Tag.EnergyWindowInformationSequence), // sequence start
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 1), // item start
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 1).thenTag(Tag.StudyDate), // study date header
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 1).thenTag(Tag.StudyDate), // study date value
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 1), // item end
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2), // item start
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence), // sequence start
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence, 1), // item start
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence, 1).thenTag(Tag.StudyDate), // Study date header
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence, 1).thenTag(Tag.StudyDate), // Study date value
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence, 1), //  item end (inserted)
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence), // sequence end (inserted)
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence, 2), // item end
-      TagPath.fromSequence(Tag.EnergyWindowInformationSequence), // sequence end
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 1), // item start
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 1).thenTag(Tag.StudyDate), // study date header
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 1).thenTag(Tag.StudyDate), // study date value
+      TagPath.fromItemEnd(Tag.EnergyWindowInformationSequence, 1), // item end
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2), // item start
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenSequence(Tag.EnergyWindowRangeSequence), // sequence start
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenItem(Tag.EnergyWindowRangeSequence, 1), // item start
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenItem(Tag.EnergyWindowRangeSequence, 1).thenTag(Tag.StudyDate), // Study date header
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenItem(Tag.EnergyWindowRangeSequence, 1).thenTag(Tag.StudyDate), // Study date value
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenItemEnd(Tag.EnergyWindowRangeSequence, 1), //  item end (inserted)
+      TagPath.fromItem(Tag.EnergyWindowInformationSequence, 2).thenSequenceEnd(Tag.EnergyWindowRangeSequence), // sequence end (inserted)
+      TagPath.fromItemEnd(Tag.EnergyWindowInformationSequence, 2), // item end
+      TagPath.fromSequenceEnd(Tag.EnergyWindowInformationSequence), // sequence end
       TagPath.fromTag(Tag.PatientName), // Patient name header
       TagPath.fromTag(Tag.PatientName), // Patient name value
       TagPath.fromTag(Tag.PixelData), // fragments start
@@ -443,19 +443,19 @@ class DicomFlowTest extends TestKit(ActorSystem("DicomFlowSpec")) with FlatSpecL
       TagPath.fromTag(Tag.PatientName),
       TagPath.fromTag(Tag.PatientName),
       TagPath.fromSequence(Tag.DigitalSignaturesSequence), // sequence start
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1), // item start
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.MACIDNumber),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.MACIDNumber),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.DigitalSignatureUID),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.DigitalSignatureUID),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateType),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateType),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateOfSigner),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateOfSigner),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.Signature),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.Signature),
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence, 1), // item end (inserted)
-      TagPath.fromSequence(Tag.DigitalSignaturesSequence)) // sequence end (inserted)
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1), // item start
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.MACIDNumber),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.MACIDNumber),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.DigitalSignatureUID),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.DigitalSignatureUID),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateType),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateType),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateOfSigner),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.CertificateOfSigner),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.Signature),
+      TagPath.fromItem(Tag.DigitalSignaturesSequence, 1).thenTag(Tag.Signature),
+      TagPath.fromItemEnd(Tag.DigitalSignaturesSequence, 1), // item end (inserted)
+      TagPath.fromSequenceEnd(Tag.DigitalSignaturesSequence)) // sequence end (inserted)
 
     def check(tagPath: TagPath): Unit = {
       tagPath shouldBe expectedPaths.head

--- a/src/test/scala/se/nimsa/dicom/streams/ElementFlowsTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/ElementFlowsTest.scala
@@ -111,11 +111,11 @@ class ElementFlowsTest extends TestKit(ActorSystem("ElementFlowsSpec")) with Fla
       }
       .request(1)
       .expectNextChainingPF {
-        case (tp: TagPath, e: ItemDelimitationElement) if e.index == 1 && tp == TagPath.fromItem(Tag.DerivationCodeSequence, 1) => true
+        case (tp: TagPath, e: ItemDelimitationElement) if e.index == 1 && tp == TagPath.fromItemEnd(Tag.DerivationCodeSequence, 1) => true
       }
       .request(1)
       .expectNextChainingPF {
-        case (tp: TagPath, _: SequenceDelimitationElement) if tp == TagPath.fromSequence(Tag.DerivationCodeSequence) => true
+        case (tp: TagPath, _: SequenceDelimitationElement) if tp == TagPath.fromSequenceEnd(Tag.DerivationCodeSequence) => true
       }
       .request(1)
       .expectNextChainingPF {

--- a/src/test/scala/se/nimsa/dicom/streams/ElementFlowsTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/ElementFlowsTest.scala
@@ -103,15 +103,15 @@ class ElementFlowsTest extends TestKit(ActorSystem("ElementFlowsSpec")) with Fla
       }
       .request(1)
       .expectNextChainingPF {
-        case (tp: TagPath, e: ItemElement) if e.index == 1 && tp == TagPath.fromSequence(Tag.DerivationCodeSequence, 1) => true
+        case (tp: TagPath, e: ItemElement) if e.index == 1 && tp == TagPath.fromItem(Tag.DerivationCodeSequence, 1) => true
       }
       .request(1)
       .expectNextChainingPF {
-        case (tp: TagPath, e: ValueElement) if e.tag == Tag.PatientName && tp == TagPath.fromSequence(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName) => true
+        case (tp: TagPath, e: ValueElement) if e.tag == Tag.PatientName && tp == TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName) => true
       }
       .request(1)
       .expectNextChainingPF {
-        case (tp: TagPath, e: ItemDelimitationElement) if e.index == 1 && tp == TagPath.fromSequence(Tag.DerivationCodeSequence, 1) => true
+        case (tp: TagPath, e: ItemDelimitationElement) if e.index == 1 && tp == TagPath.fromItem(Tag.DerivationCodeSequence, 1) => true
       }
       .request(1)
       .expectNextChainingPF {

--- a/src/test/scala/se/nimsa/dicom/streams/ModifyFlowTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/ModifyFlowTest.scala
@@ -31,9 +31,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty, insert = false),
-        TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = false)))
+      .via(modifyFlow(modifications = Seq(
+        TagModification.equals(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty),
+        TagModification.equals(TagPath.fromTag(Tag.PatientName), _ => mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, 0)
@@ -49,7 +49,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = false)))
+      .via(modifyFlow(modifications = Seq(TagModification.equals(TagPath.fromTag(Tag.PatientName), _ => mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -68,7 +68,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.StudyDate), studyDate().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, studyDate().length - 8)
@@ -83,7 +83,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => patientNameJohnDoe().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.PatientName), patientNameJohnDoe().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, studyDate().length - 8)
@@ -98,7 +98,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.SOPInstanceUID), _ => ByteString("1.2.3.4 "), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.SOPInstanceUID), ByteString("1.2.3.4 ")))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.SOPInstanceUID, VR.UI, 8)
@@ -112,7 +112,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => patientNameJohnDoe().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.PatientName), patientNameJohnDoe().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, studyDate().length - 8)
@@ -129,7 +129,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => patientNameJohnDoe().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.PatientName), patientNameJohnDoe().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -146,7 +146,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => patientNameJohnDoe().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.PatientName), patientNameJohnDoe().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -165,9 +165,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty, insert = true),
-        TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = true)))
+      .via(modifyFlow(insertions = Seq(
+        TagInsertion(TagPath.fromTag(Tag.StudyDate), ByteString.empty),
+        TagInsertion(TagPath.fromTag(Tag.PatientName), mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, 0)
@@ -181,9 +181,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(Tag.SeriesDate), _ => studyDate().drop(8), insert = true),
-        TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(
+        TagInsertion(TagPath.fromTag(Tag.SeriesDate), studyDate().drop(8)),
+        TagInsertion(TagPath.fromTag(Tag.StudyDate), studyDate().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, studyDate().length - 8)
@@ -198,7 +198,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
   it should "not insert elements if dataset contains no elements" in {
     val source = Source.empty
       .via(parseFlow)
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.SeriesDate), _ => studyDate().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.SeriesDate), studyDate().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectDicomComplete()
@@ -209,8 +209,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence, 1).thenTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.StudyDate), studyDate().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -229,9 +228,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence).thenTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true),
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientName), _ => ByteString.empty, insert = true)))
+      .via(modifyFlow(insertions = Seq(
+        TagInsertion(TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.StudyDate), studyDate().drop(8)),
+        TagInsertion(TagPath.fromItem(Tag.DerivationCodeSequence, 1).thenTag(Tag.PatientName), ByteString.empty))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.PatientName)
@@ -244,8 +243,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(0x00200021), _ => ByteString(1, 2, 3, 4), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(0x00200021), ByteString(1, 2, 3, 4)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.PatientName)
@@ -258,8 +256,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(Tag.DerivationCodeSequence), _ => ByteString.empty, insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.DerivationCodeSequence), ByteString.empty))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectDicomError()
@@ -270,8 +267,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence, 2).thenTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromItem(Tag.DerivationCodeSequence, 2).thenTag(Tag.StudyDate), studyDate().drop(8)))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -296,8 +292,8 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence, 2).thenTag(Tag.PatientName), _ => mikeBytes, insert = false)))
+      .via(modifyFlow(modifications = Seq(
+        TagModification.equals(TagPath.fromItem(Tag.DerivationCodeSequence, 2).thenTag(Tag.PatientName), _ => mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -313,41 +309,15 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
       .expectDicomComplete()
   }
 
-  it should "insert into all sequence items" in {
-    val bytes = sequence(Tag.DerivationCodeSequence) ++ item() ++ patientNameJohnDoe() ++ itemDelimitation() ++ item() ++ patientNameJohnDoe() ++ itemDelimitation() ++ sequenceDelimitation()
-
-    val source = Source.single(bytes)
-      .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence).thenTag(Tag.StudyDate), _ => studyDate().drop(8), insert = true)))
-
-    source.runWith(TestSink.probe[DicomPart])
-      .expectSequence(Tag.DerivationCodeSequence)
-      .expectItem(1)
-      .expectHeader(Tag.StudyDate)
-      .expectValueChunk()
-      .expectHeader(Tag.PatientName)
-      .expectValueChunk()
-      .expectItemDelimitation()
-      .expectItem(2)
-      .expectHeader(Tag.StudyDate)
-      .expectValueChunk()
-      .expectHeader(Tag.PatientName)
-      .expectValueChunk()
-      .expectItemDelimitation()
-      .expectSequenceDelimitation()
-      .expectDicomComplete()
-  }
-
   it should "modify all sequence items" in {
     val bytes = sequence(Tag.DerivationCodeSequence) ++ item() ++ patientNameJohnDoe() ++ itemDelimitation() ++ item() ++ patientNameJohnDoe() ++ itemDelimitation() ++ sequenceDelimitation()
 
     val mikeBytes = ByteString('M', 'i', 'k', 'e')
+    val tagTree = TagTree.fromAnyItem(Tag.DerivationCodeSequence).thenTag(Tag.PatientName)
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromSequence(Tag.DerivationCodeSequence).thenTag(Tag.PatientName), _ => mikeBytes, insert = false)))
+      .via(modifyFlow(modifications = Seq(TagModification(tagTree.hasBranch, _ => mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)
@@ -370,8 +340,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(
-        TagModification.contains(TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = true)))
+      .via(modifyFlow(insertions = Seq(TagInsertion(TagPath.fromTag(Tag.PatientName), mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectPreamble()
@@ -393,7 +362,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(TagModification.endsWith(TagPath.fromTag(Tag.StudyDate), _ => studyBytes, insert = false)))
+      .via(modifyFlow(modifications = Seq(TagModification.endsWith(TagPath.fromTag(Tag.StudyDate), _ => studyBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate)
@@ -416,9 +385,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .prepend(Source.single(TagModificationsPart(List(TagModification.contains(
-          TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = false)))))
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty, insert = false)))
+      .prepend(Source.single(TagModificationsPart(Seq(TagModification.equals(
+        TagPath.fromTag(Tag.PatientName), _ => mikeBytes)), Seq.empty)))
+      .via(modifyFlow(modifications = Seq(TagModification.equals(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate, VR.DA, 0)
@@ -434,9 +403,9 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .prepend(Source.single(TagModificationsPart(List(TagModification.contains(
-        TagPath.fromTag(Tag.PatientName), _ => mikeBytes, insert = false)), replace = true)))
-      .via(modifyFlow(TagModification.contains(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty, insert = false)))
+      .prepend(Source.single(TagModificationsPart(Seq(TagModification.equals(
+        TagPath.fromTag(Tag.PatientName), _ => mikeBytes)), Seq.empty, replace = true)))
+      .via(modifyFlow(modifications = Seq(TagModification.equals(TagPath.fromTag(Tag.StudyDate), _ => ByteString.empty))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.StudyDate)

--- a/src/test/scala/se/nimsa/dicom/streams/ModifyFlowTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/ModifyFlowTest.scala
@@ -317,7 +317,7 @@ class ModifyFlowTest extends TestKit(ActorSystem("ModifyFlowSpec")) with FlatSpe
 
     val source = Source.single(bytes)
       .via(parseFlow)
-      .via(modifyFlow(modifications = Seq(TagModification(tagTree.hasBranch, _ => mikeBytes))))
+      .via(modifyFlow(modifications = Seq(TagModification(tagTree.hasPath, _ => mikeBytes))))
 
     source.runWith(TestSink.probe[DicomPart])
       .expectSequence(Tag.DerivationCodeSequence)

--- a/src/test/scala/se/nimsa/dicom/streams/ParseFlowTest.scala
+++ b/src/test/scala/se/nimsa/dicom/streams/ParseFlowTest.scala
@@ -468,7 +468,6 @@ class ParseFlowTest extends TestKit(ActorSystem("ParseFlowSpec")) with FlatSpecL
 
     val source = Source.single(bytes)
       .via(new ParseFlow())
-      .via(DicomFlows.printFlow)
 
     source.runWith(TestSink.probe[DicomPart])
       .expectHeader(Tag.PatientName)


### PR DESCRIPTION
Close #25 

TagPath is an important data structure and is used throughout this library. In some places, code using tag paths has become error prone and non-obvious due to the limited type safety of this class. TagPath has types to represent simple tag nodes as well as sequences and items and has until now also supprted wildcards in its item specification, supporting tag paths that are really tag trees spanning multiple branches across a dataset. There was no way of telling from the type signature of a tag path whether it contained wildcards somewhere along the path, and thus was a tag tree rather than a tag path. Many methods require the path to be a single path and would throw a runtime error if a wildcard was detected. This PR improves the type safety by splitting TagPath into two classes, TagPath for simple paths, and TagTree for paths supporting wildcards. Additionally, new specializations of TagPath has been added to represent the end of a sequence (TagPathSequenceEnd) and the end of an item (TagPathItemEnd). This makes it possible to define an ordering of all DICOM parts encountered when parsing a file. 

This PR also fixes bug #25 quite easily using the new type system and nomenclature. 

